### PR TITLE
Implement Steffen-style monotone curves

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ export {default as diamond} from "./src/symbol/diamond";
 export {default as linearClosed} from "./src/curve/linear-closed";
 export {default as linear} from "./src/curve/linear";
 export {default as line} from "./src/line";
+export {default as monotone} from "./src/curve/monotone";
 export {default as natural} from "./src/curve/natural";
 export {default as square} from "./src/symbol/square";
 export {default as stepAfter} from "./src/curve/step-after";

--- a/src/curve/monotone.js
+++ b/src/curve/monotone.js
@@ -1,3 +1,37 @@
+function sign(x) {
+  return x < 0 ? -1 : 1;
+}
+
+// Calculate the slopes of the tangents (Hermite-type interpolation) based on
+// the following paper: Steffen, M. 1990. A Simple Method for Monotonic
+// Interpolation in One Dimension. Astronomy and Astrophysics, Vol. 239, NO.
+// NOV(II), P. 443, 1990.
+function slope(that, x, y) {
+  var h0 = that._x1 - that._x0,
+      h1 = x - that._x1,
+      s0 = h0 === 0 ? 0 : (that._y1 - that._y0) / h0,
+      s1 = h1 === 0 ? 0 : (y - that._y1) / h1,
+      p = h0 + h1 === 0 ? 0 : (s0 * h1 + s1 * h0) / (h0 + h1);
+
+  return (sign(s0) + sign(s1)) * Math.min(Math.abs(s0), Math.abs(s1), 0.5 * Math.abs(p));
+}
+
+function point(that, t1) {
+  var dx,
+      x0 = that._x0,
+      y0 = that._y0,
+      x1 = that._x1,
+      y1 = that._y1,
+      t0 = that._t0;
+
+  // According to https://en.wikipedia.org/wiki/Cubic_Hermite_spline#Representations
+  // "you can express cubic Hermite interpolation in terms of cubic
+  // Bézier curves with respect to the four values p0, p0 + m0 / 3, p1 -
+  // m1 / 3, p1".
+  dx = (x1 - x0) / 3.0;
+  that._context.bezierCurveTo(x0 + dx, y0 + dx * t0, x1 - dx, y1 - dx * t1, x1, y1);
+}
+
 function monotone(context) {
     return new Monotone(context);
 }
@@ -14,74 +48,32 @@ Monotone.prototype = {
     this._line = NaN;
   },
   lineStart: function() {
-    this._x = [];
-    this._y = [];
+    this._x0 = this._x1 =
+    this._y0 = this._y1 = NaN;
+    this._t0 = this._point = 0;
   },
   lineEnd: function() {
-    var x = this._x,
-        y = this._y,
-        n = x.length;
-
-    if (n) {
-      this._line ? this._context.lineTo(x[0], y[0]) : this._context.moveTo(x[0], y[0]);
-      if (n === 2) {
-        this._context.lineTo(x[1], y[1]);
-      } else {
-        var dx,
-            s = slopes(x, y);
-
-        for (var i0 = 0, i1 = 1; i1 < n; ++i0, ++i1) {
-          // According to https://en.wikipedia.org/wiki/Cubic_Hermite_spline#Representations
-          // "you can express cubic Hermite interpolation in terms of cubic
-          // Bézier curves with respect to the four values p0, p0 + m0 / 3, p1 -
-          // m1 / 3, p1".
-          dx = (x[i1] - x[i0]) / 3.0;
-          this._context.bezierCurveTo(x[i0] + dx, y[i0] + dx * s[i0], x[i1] - dx, y[i1] - dx * s[i1], x[i1], y[i1]);
-        }
-      }
+    switch (this._point) {
+      case 2: this._context.lineTo(this._x1, this._y1); break;
+      case 3: point(this, 0); break;
     }
-
-    if (this._line || (this._line !== 0 && n === 1)) this._context.closePath();
+    if (this._line || (this._line !== 0 && this._point === 1)) this._context.closePath();
     this._line = 1 - this._line;
-    this._x = this._y = null;
   },
   point: function(x, y) {
-    this._x.push(+x);
-    this._y.push(+y);
+    var t1 = 0;
+
+    x = +x, y = +y;
+    switch (this._point) {
+      case 0: this._point = 1; this._line ? this._context.lineTo(x, y) : this._context.moveTo(x, y); break;
+      case 1: this._point = 2; break;
+      case 2: this._point = 3; // proceed
+      default: t1 = slope(this, x, y); point(this, t1); break;
+    }
+    this._x0 = this._x1, this._x1 = x;
+    this._y0 = this._y1, this._y1 = y;
+    this._t0 = t1;
   }
-}
-
-function sign(x) {
-  return x < 0 ? -1 : 1;
-}
-
-// Calculate the slopes of the tangents (Hermite-type interpolation) based on
-// the following paper: Steffen, M. 1990. A Simple Method for Monotonic
-// Interpolation in One Dimension. Astronomy and Astrophysics, Vol. 239, NO.
-// NOV(II), P. 443, 1990.
-function slopes(x, y) {
-  var h0,
-      h1,
-      s0,
-      s1,
-      p,
-      l = x.length,
-      t = new Array(l);
-
-  for (var i = 1; i < l - 1; i++) {
-    h0 = x[i] - x[i - 1];
-    h1 = x[i + 1] - x[i];
-    s0 = h0 === 0 ? 0 : (y[i] - y[i - 1]) / h0;
-    s1 = h1 === 0 ? 0 : (y[i + 1] - y[i]) / h1;
-    p = h0 + h1 === 0 ? 0 : (s0 * h1 + s1 * h0) / (h0 + h1);
-    t[i] = (sign(s0) + sign(s1)) * Math.min(Math.abs(s0), Math.abs(s1), 0.5 * Math.abs(p));
-  }
-
-  // Easiest option for handling boundary points: just choose to set the slope to 0.
-  t[0] = 0;
-  t[l - 1] = 0;
-
-  return t;
 }
 
 export default monotone;


### PR DESCRIPTION
This set of changes implements monotone curves based on ```src/curve/natural.js``` and the following paper: *Steffen, M. 1990. A Simple Method for Monotonic Interpolation in One Dimension. Astronomy and Astrophysics, Vol. 239, NO. NOV(II), P. 443, 1990.* The paper is readable at http://adsabs.harvard.edu/full/1990A%26A...239..443S.

The implementation makes a couple of choices aiming to streamline the code. First, the slope at the boundary points is set to zero, which generally looks ok when plotting line graphs. The paper also offers other good suggestions, such as using the slope of the line going through the boundary point and the point next to it.

Second, the slope is just set to zero on certain cases when the *x<sub>i</sub>* values are not strictly monotonic, such as when *(x<sub>i</sub> - x<sub>i-1</sub>) = 0* or when *(x<sub>i</sub> - x<sub>i-1</sub>) + (x<sub>i+1</sub> - x<sub>i</sub>) = 0*.

This also modifies ```index.js``` to expose the implementation as ```monotone```.

I hope this is useful, but should this not be suitable for d3-shape I can make it a plugin or something like that.