### PR TITLE
Asymmetric arc and pie padding.

### DIFF
--- a/src/arc.js
+++ b/src/arc.js
@@ -126,20 +126,24 @@ export default function() {
           a10 = a1,
           da0 = da,
           da1 = da,
-          ap = padAngle.apply(this, arguments) / 2,
-          rp = (ap > 0) && (padRadius ? +padRadius.apply(this, arguments) : Math.sqrt(r0 * r0 + r1 * r1)),
+          ap = padAngle.apply(this, arguments),
+          ap0 = (Array.isArray(ap) ? +ap[0] : ap / 2),
+          ap1 = (Array.isArray(ap) ? +ap[1] : ap / 2),
+          rp = (ap0 > 0 || ap1 > 0) && (padRadius ? +padRadius.apply(this, arguments) : Math.sqrt(r0 * r0 + r1 * r1)),
           rc = Math.min(Math.abs(r1 - r0) / 2, +cornerRadius.apply(this, arguments)),
           rc0 = rc,
           rc1 = rc;
 
       // Apply padding? Note that since r1 ≥ r0, da1 ≥ da0.
       if (rp > 0) {
-        var p0 = asin(rp / r0 * Math.sin(ap)),
-            p1 = asin(rp / r1 * Math.sin(ap));
-        if ((da0 -= p0 * 2) > 0) p0 *= (cw ? 1 : -1), a00 += p0, a10 -= p0;
-        else da0 = 0, a00 = a10 = (a0 + a1) / 2;
-        if ((da1 -= p1 * 2) > 0) p1 *= (cw ? 1 : -1), a01 += p1, a11 -= p1;
-        else da1 = 0, a01 = a11 = (a0 + a1) / 2;
+        var p00 = asin(rp / r0 * Math.sin(ap0)),
+            p01 = asin(rp / r0 * Math.sin(ap1)),
+            p10 = asin(rp / r1 * Math.sin(ap0)),
+            p11 = asin(rp / r1 * Math.sin(ap1));
+        if ((da0 -= p00 + p01) > 0) a00 += p00 * (cw ? 1 : -1), a10 -= p01 * (cw ? 1 : -1);
+        else da0 = 0, a00 = a10 = (a0 * p01 + a1 * p00) / (p00 + p01);
+        if ((da1 -= p10 + p11) > 0) a01 += p10 * (cw ? 1 : -1), a11 -= p11 * (cw ? 1 : -1);
+        else da1 = 0, a01 = a11 = (a0 * p11 + a1 * p10) / (p10 + p11);
       }
 
       var x01 = r1 * Math.cos(a01),

--- a/src/pie.js
+++ b/src/pie.js
@@ -26,7 +26,7 @@ export default function() {
         a0 = +startAngle.apply(this, arguments),
         da = endAngle.apply(this, arguments) - a0,
         a1,
-        p = Math.min(Math.abs(da) / n, padAngle.apply(this, arguments)),
+        p = Math.min(Math.abs(da) / (n - 1), padAngle.apply(this, arguments)),
         pa = p * (da < 0 ? -1 : 1);
 
     for (var i = 0, v; i < n; ++i) {
@@ -40,13 +40,13 @@ export default function() {
     else if (sort !== null) index.sort(function(i, j) { return sort(data[i], data[j]); });
 
     // Compute the arcs! They are stored in the original data's order.
-    for (var i = 0, j, k = sum ? (da - n * pa) / sum : 0; i < n; ++i, a0 = a1) {
-      j = index[i], v = arcs[j], a1 = a0 + (v > 0 ? v * k : 0) + pa, arcs[j] = {
+    for (var i = 0, j, k = sum ? (da - (n - 1) * pa) / sum : 0; i < n; ++i, a0 = a1) {
+      j = index[i], v = arcs[j], a1 = a0 + (v > 0 ? v * k : 0) + (i === 0 || i === n - 1 ? pa / 2 : pa), arcs[j] = {
         data: data[j],
         value: v,
         startAngle: a0,
         endAngle: a1,
-        padAngle: p
+        padAngle: i === 0 ? [0, p / 2] : i === n - 1 ? [p / 2, 0] : [p / 2, p / 2]
       };
     }
 


### PR DESCRIPTION
Fixes mbostock/d3#2237. Related #41. TODO:
- [ ] Switch to symmetric padding if |endAngle - startAngle| ≥ τ.
- [ ] Don’t duplicate calculation of `p / 2`.
- [ ] Maybe don’t duplicate padding distance calculations if ap0 = ap1?
- [ ] Verify that the weighted midpoint during padding collapse is correct.
