### PR TITLE
Adds cornerRadius parameter to arc

### DIFF
--- a/src/arc.js
+++ b/src/arc.js
@@ -22,6 +22,10 @@ function arcPadAngle(d) {
   return d && d.padAngle; // Note: optional!
 }
 
+function arcCornerRadius(d) {
+  return d.cornerRadius;
+}
+
 function asin(x) {
   return x >= 1 ? halfPi : x <= -1 ? -halfPi : Math.asin(x);
 }
@@ -253,6 +257,10 @@ export default function() {
 
   arc.padAngle = function(_) {
     return arguments.length ? (padAngle = typeof _ === "function" ? _ : constant(+_), arc) : padAngle;
+  };
+
+  arc.cornerRadius = function(_) {
+    return arguments.length ? (cornerRadius = typeof _ === "function" ? _ : constant(+_), arc) : cornerRadius;
   };
 
   arc.context = function(_) {


### PR DESCRIPTION
Hi guys,

I'm doing a small library for doing charts with react native and I realized that `cornerRadius` parameter was being ignored in the most recent `d3` version (installed via `yarn`, v4.3.0).
Here is a failing example (ecmascript 2015):


```javascript
  data = [1,2,3];
  const innerRadius = 30;
  const outerRadius = 50;
  const cornerRadius = 10;
  const arcs = d3.shape.pie()(data);
  const arc = d3.shape.arc();
  return arcs.map((a) => {
    return arc({ ...a, innerRadius, outerRadius, cornerRadius });
  }
  );
}
```

I did some debugging using `console.log` with the example above and realized that `cornerRadius` was always set to 0 and whatever was passed in `parameters` was ignored. 

I did the fix that I'm sending in this PR, and it works well for me locally. Is there anything that I might be missing?

I noticed that there is one `cornerRadius` test (https://github.com/d3/d3-shape/blob/master/test/arc-test.js#L20), can you provide me with some guidelines to run the tests?

