### PR TITLE
Adds cornerRadius parameter to arc

### DIFF
--- a/src/arc.js
+++ b/src/arc.js
@@ -22,6 +22,10 @@ function arcPadAngle(d) {
   return d && d.padAngle; // Note: optional!
 }
 
+function arcCornerRadius(d) {
+  return (d && d.cornerRadius) || 0;
+}
+
 function asin(x) {
   return x >= 1 ? halfPi : x <= -1 ? -halfPi : Math.asin(x);
 }
@@ -79,7 +83,7 @@ function cornerTangents(x0, y0, x1, y1, r1, rc, cw) {
 export default function() {
   var innerRadius = arcInnerRadius,
       outerRadius = arcOuterRadius,
-      cornerRadius = constant(0),
+      cornerRadius = arcCornerRadius,
       padRadius = null,
       startAngle = arcStartAngle,
       endAngle = arcEndAngle,


### PR DESCRIPTION
Ok so this is the follow up from my wrongful PR, #84 . I think it should be correct now. The problem is still the same:

> I'm doing a small library for doing charts with react native and I realized that `cornerRadius` parameter was being ignored in the most recent `d3` version (installed via `yarn`, v4.3.0).
> Here is a failing example (ecmascript 2015):


```javascript
  data = [1,2,3];
  const innerRadius = 30;
  const outerRadius = 50;
  const cornerRadius = 10;
  const arcs = d3.shape.pie()(data);
  const arc = d3.shape.arc();
  return arcs.map((a) => {
    return arc({ ...a, innerRadius, outerRadius, cornerRadius });
  }
  );
}
```

> I did some debugging using `console.log` with the example above and realized that `cornerRadius` was always set to 0 and whatever was passed in `parameters` was ignored. 

> I did the fix that I'm sending in this PR, and it works well for me locally. Is there anything that I might be missing?

Also, I just ran `npm run test` so my question was a bit stupod... 😊 ooops, sorry about that 😄 

Thanks in advance!