### PR TITLE
Removed implicit conversion of points for curve functions

### DIFF
--- a/src/line.js
+++ b/src/line.js
@@ -25,7 +25,7 @@ export default function() {
         if (defined0 = !defined0) output.lineStart();
         else output.lineEnd();
       }
-      if (defined0) output.point(+x(d, i, data), +y(d, i, data));
+      if (defined0) output.point(x(d, i, data), y(d, i, data));
     }
 
     if (buffer) return output = null, buffer + "" || null;


### PR DESCRIPTION
Hello,

it might be required to deliver meta information with your value, if you are using an custom curve.
The conversion is not necessary neither, as the d3 provided curve functions already do the trick.

So we are limiting the point function of an curve to number types only.
If you are using an self defined curve class, you will take care of the given data, if not you will use the build in ones that will do.

It would be nice to hear your opinion. :)
Regards!