### PR TITLE
Fix #90 - Clamp acos when computing rounded corners

### DIFF
--- a/src/arc.js
+++ b/src/arc.js
@@ -1,6 +1,6 @@
 import {path} from "d3-path";
 import constant from "./constant";
-import {epsilon, pi, halfPi, tau} from "./math";
+import {acos, epsilon, pi, halfPi, tau} from "./math";
 
 function arcInnerRadius(d) {
   return d.innerRadius;
@@ -159,7 +159,7 @@ export default function() {
               ay = y01 - oc[1],
               bx = x11 - oc[0],
               by = y11 - oc[1],
-              kc = 1 / Math.sin(Math.acos((ax * bx + ay * by) / (Math.sqrt(ax * ax + ay * ay) * Math.sqrt(bx * bx + by * by))) / 2),
+              kc = 1 / Math.sin(acos((ax * bx + ay * by) / (Math.sqrt(ax * ax + ay * ay) * Math.sqrt(bx * bx + by * by))) / 2),
               lc = Math.sqrt(oc[0] * oc[0] + oc[1] * oc[1]);
           rc0 = Math.min(rc, (r0 - lc) / (kc - 1));
           rc1 = Math.min(rc, (r1 - lc) / (kc + 1));

--- a/src/math.js
+++ b/src/math.js
@@ -2,3 +2,7 @@ export var epsilon = 1e-12;
 export var pi = Math.PI;
 export var halfPi = pi / 2;
 export var tau = 2 * pi;
+
+export function acos(x) {
+  return x > 1 ? 0 : x < -1 ? pi : Math.acos(x);
+}


### PR DESCRIPTION
Due to floating point imprecision, computing the angle between two
vectors with `theta = acos((a . b) / sqrt(|a||b|))` gives NaN when
`(a . b) / sqrt(|a||b|)` is outside the domain of `acos`. We can
use a clamped version of acos to avoid this, which clamps to
[-1, 1].