### PR TITLE
README: Update line chart block url

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ The pad angle here means the angular separation between each adjacent arc. The t
 
 ### Lines
 
-[<img width="295" height="154" alt="Line Chart" src="https://raw.githubusercontent.com/d3/d3-shape/master/img/line.png">](http://bl.ocks.org/mbostock/1550e57e12e73b86ad9e)
+[<img width="295" height="154" alt="Line Chart" src="https://raw.githubusercontent.com/d3/d3-shape/master/img/line.png">](https://bl.ocks.org/mbostock/3883245)
 
 The line generator produces a [spline](https://en.wikipedia.org/wiki/Spline_\(mathematics\)) or [polyline](https://en.wikipedia.org/wiki/Polygonal_chain), as in a line chart. Lines also appear in many other visualization types, such as the links in [hierarchical edge bundling](http://bl.ocks.org/mbostock/7607999).
 


### PR DESCRIPTION
The new url uses mbostock's latest version of the canvas line chart, which uses the current v4 instead of the alpha.
The main reason why this change is necessary is the use of `d3.tsv` instead of `d3.requestTsv` (`requestTsv` does not seem to exist in the latest version of d3)