### PR TITLE
curve option for linkHorizontal and linkVertical

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ The arc generator produces a [circular](https://en.wikipedia.org/wiki/Circular_s
 
 See also the [pie generator](#pies), which computes the necessary angles to represent an array of data as a pie or donut chart; these angles can then be passed to an arc generator.
 
-<a name="arc" href="#arc">#</a> d3.<b>arc</b>() · [Source](https://github.com/d3/d3-shape/blob/master/src/arc.js)
+<a name="arc" href="#arc">#</a> d3.<b>arc</b>() · [Source](https://github.com/d3/d3-shape/blob/main/src/arc.js)
 
 Constructs a new arc generator with the default settings.
 
-<a name="_arc" href="#_arc">#</a> <i>arc</i>(<i>arguments…</i>) · [Source](https://github.com/d3/d3-shape/blob/master/src/arc.js)
+<a name="_arc" href="#_arc">#</a> <i>arc</i>(<i>arguments…</i>) · [Source](https://github.com/d3/d3-shape/blob/main/src/arc.js)
 
 Generates an arc for the given *arguments*. The *arguments* are arbitrary; they are simply propagated to the arc generator’s accessor functions along with the `this` object. For example, with the default settings, an object with radii and angles is expected:
 
@@ -106,7 +106,7 @@ arc(); // "M0,-100A100,100,0,0,1,100,0L0,0Z"
 
 If the arc generator has a [context](#arc_context), then the arc is rendered to this context as a sequence of [path method](http://www.w3.org/TR/2dcontext/#canvaspathmethods) calls and this function returns void. Otherwise, a [path data](http://www.w3.org/TR/SVG/paths.html#PathData) string is returned.
 
-<a name="arc_centroid" href="#arc_centroid">#</a> <i>arc</i>.<b>centroid</b>(<i>arguments…</i>) · [Source](https://github.com/d3/d3-shape/blob/master/src/arc.js)
+<a name="arc_centroid" href="#arc_centroid">#</a> <i>arc</i>.<b>centroid</b>(<i>arguments…</i>) · [Source](https://github.com/d3/d3-shape/blob/main/src/arc.js)
 
 Computes the midpoint [*x*, *y*] of the center line of the arc that would be [generated](#_arc) by the given *arguments*. The *arguments* are arbitrary; they are simply propagated to the arc generator’s accessor functions along with the `this` object. To be consistent with the generated arc, the accessors must be deterministic, *i.e.*, return the same value given the same arguments. The midpoint is defined as ([startAngle](#arc_startAngle) + [endAngle](#arc_endAngle)) / 2 and ([innerRadius](#arc_innerRadius) + [outerRadius](#arc_outerRadius)) / 2. For example:
 
@@ -114,7 +114,7 @@ Computes the midpoint [*x*, *y*] of the center line of the arc that would be [ge
 
 Note that this is **not the geometric center** of the arc, which may be outside the arc; this method is merely a convenience for positioning labels.
 
-<a name="arc_innerRadius" href="#arc_innerRadius">#</a> <i>arc</i>.<b>innerRadius</b>([<i>radius</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/arc.js)
+<a name="arc_innerRadius" href="#arc_innerRadius">#</a> <i>arc</i>.<b>innerRadius</b>([<i>radius</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/arc.js)
 
 If *radius* is specified, sets the inner radius to the specified function or number and returns this arc generator. If *radius* is not specified, returns the current inner radius accessor, which defaults to:
 
@@ -126,7 +126,7 @@ function innerRadius(d) {
 
 Specifying the inner radius as a function is useful for constructing a stacked polar bar chart, often in conjunction with a [sqrt scale](https://github.com/d3/d3-scale#sqrt). More commonly, a constant inner radius is used for a donut or pie chart. If the outer radius is smaller than the inner radius, the inner and outer radii are swapped. A negative value is treated as zero.
 
-<a name="arc_outerRadius" href="#arc_outerRadius">#</a> <i>arc</i>.<b>outerRadius</b>([<i>radius</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/arc.js)
+<a name="arc_outerRadius" href="#arc_outerRadius">#</a> <i>arc</i>.<b>outerRadius</b>([<i>radius</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/arc.js)
 
 If *radius* is specified, sets the outer radius to the specified function or number and returns this arc generator. If *radius* is not specified, returns the current outer radius accessor, which defaults to:
 
@@ -138,7 +138,7 @@ function outerRadius(d) {
 
 Specifying the outer radius as a function is useful for constructing a coxcomb or polar bar chart, often in conjunction with a [sqrt scale](https://github.com/d3/d3-scale#sqrt). More commonly, a constant outer radius is used for a pie or donut chart. If the outer radius is smaller than the inner radius, the inner and outer radii are swapped. A negative value is treated as zero.
 
-<a name="arc_cornerRadius" href="#arc_cornerRadius">#</a> <i>arc</i>.<b>cornerRadius</b>([<i>radius</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/arc.js)
+<a name="arc_cornerRadius" href="#arc_cornerRadius">#</a> <i>arc</i>.<b>cornerRadius</b>([<i>radius</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/arc.js)
 
 If *radius* is specified, sets the corner radius to the specified function or number and returns this arc generator. If *radius* is not specified, returns the current corner radius accessor, which defaults to:
 
@@ -154,7 +154,7 @@ If the corner radius is greater than zero, the corners of the arc are rounded us
 
 The corner radius may not be larger than ([outerRadius](#arc_outerRadius) - [innerRadius](#arc_innerRadius)) / 2. In addition, for arcs whose angular span is less than π, the corner radius may be reduced as two adjacent rounded corners intersect. This is occurs more often with the inner corners. See the [arc corners animation](http://bl.ocks.org/mbostock/b7671cb38efdfa5da3af) for illustration.
 
-<a name="arc_startAngle" href="#arc_startAngle">#</a> <i>arc</i>.<b>startAngle</b>([<i>angle</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/arc.js)
+<a name="arc_startAngle" href="#arc_startAngle">#</a> <i>arc</i>.<b>startAngle</b>([<i>angle</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/arc.js)
 
 If *angle* is specified, sets the start angle to the specified function or number and returns this arc generator. If *angle* is not specified, returns the current start angle accessor, which defaults to:
 
@@ -166,7 +166,7 @@ function startAngle(d) {
 
 The *angle* is specified in radians, with 0 at -*y* (12 o’clock) and positive angles proceeding clockwise. If |endAngle - startAngle| ≥ τ, a complete circle or annulus is generated rather than a sector.
 
-<a name="arc_endAngle" href="#arc_endAngle">#</a> <i>arc</i>.<b>endAngle</b>([<i>angle</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/arc.js)
+<a name="arc_endAngle" href="#arc_endAngle">#</a> <i>arc</i>.<b>endAngle</b>([<i>angle</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/arc.js)
 
 If *angle* is specified, sets the end angle to the specified function or number and returns this arc generator. If *angle* is not specified, returns the current end angle accessor, which defaults to:
 
@@ -178,7 +178,7 @@ function endAngle(d) {
 
 The *angle* is specified in radians, with 0 at -*y* (12 o’clock) and positive angles proceeding clockwise. If |endAngle - startAngle| ≥ τ, a complete circle or annulus is generated rather than a sector.
 
-<a name="arc_padAngle" href="#arc_padAngle">#</a> <i>arc</i>.<b>padAngle</b>([<i>angle</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/arc.js)
+<a name="arc_padAngle" href="#arc_padAngle">#</a> <i>arc</i>.<b>padAngle</b>([<i>angle</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/arc.js)
 
 If *angle* is specified, sets the pad angle to the specified function or number and returns this arc generator. If *angle* is not specified, returns the current pad angle accessor, which defaults to:
 
@@ -198,11 +198,11 @@ The recommended minimum inner radius when using padding is outerRadius \* padAng
 
 Often, the pad angle is not set directly on the arc generator, but is instead computed by the [pie generator](#pies) so as to ensure that the area of padded arcs is proportional to their value; see [*pie*.padAngle](#pie_padAngle). See the [pie padding animation](http://bl.ocks.org/mbostock/3e961b4c97a1b543fff2) for illustration. If you apply a constant pad angle to the arc generator directly, it tends to subtract disproportionately from smaller arcs, introducing distortion.
 
-<a name="arc_padRadius" href="#arc_padRadius">#</a> <i>arc</i>.<b>padRadius</b>([<i>radius</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/arc.js)
+<a name="arc_padRadius" href="#arc_padRadius">#</a> <i>arc</i>.<b>padRadius</b>([<i>radius</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/arc.js)
 
 If *radius* is specified, sets the pad radius to the specified function or number and returns this arc generator. If *radius* is not specified, returns the current pad radius accessor, which defaults to null, indicating that the pad radius should be automatically computed as sqrt([innerRadius](#arc_innerRadius) * innerRadius + [outerRadius](#arc_outerRadius) * outerRadius). The pad radius determines the fixed linear distance separating adjacent arcs, defined as padRadius * [padAngle](#arc_padAngle).
 
-<a name="arc_context" href="#arc_context">#</a> <i>arc</i>.<b>context</b>([<i>context</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/arc.js)
+<a name="arc_context" href="#arc_context">#</a> <i>arc</i>.<b>context</b>([<i>context</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/arc.js)
 
 If *context* is specified, sets the context and returns this arc generator. If *context* is not specified, returns the current context, which defaults to null. If the context is not null, then the [generated arc](#_arc) is rendered to this context as a sequence of [path method](http://www.w3.org/TR/2dcontext/#canvaspathmethods) calls. Otherwise, a [path data](http://www.w3.org/TR/SVG/paths.html#PathData) string representing the generated arc is returned.
 
@@ -210,11 +210,11 @@ If *context* is specified, sets the context and returns this arc generator. If *
 
 The pie generator does not produce a shape directly, but instead computes the necessary angles to represent a tabular dataset as a pie or donut chart; these angles can then be passed to an [arc generator](#arcs).
 
-<a name="pie" href="#pie">#</a> d3.<b>pie</b>() · [Source](https://github.com/d3/d3-shape/blob/master/src/pie.js)
+<a name="pie" href="#pie">#</a> d3.<b>pie</b>() · [Source](https://github.com/d3/d3-shape/blob/main/src/pie.js)
 
 Constructs a new pie generator with the default settings.
 
-<a name="_pie" href="#_pie">#</a> <i>pie</i>(<i>data</i>[, <i>arguments…</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/pie.js)
+<a name="_pie" href="#_pie">#</a> <i>pie</i>(<i>data</i>[, <i>arguments…</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/pie.js)
 
 Generates a pie for the given array of *data*, returning an array of objects representing each datum’s arc angles. Any additional *arguments* are arbitrary; they are simply propagated to the pie generator’s accessor functions along with the `this` object. The length of the returned array is the same as *data*, and each element *i* in the returned array corresponds to the element *i* in the input data. Each object in the returned array has the following properties:
 
@@ -251,7 +251,7 @@ The first pair of parens, `pie()`, [constructs](#pie) a default pie generator. T
 
 Note that the returned array is in the same order as the data, even though this pie chart is [sorted](#pie_sortValues) by descending value, starting with the arc for the last datum (value 21) at 12 o’clock.
 
-<a name="pie_value" href="#pie_value">#</a> <i>pie</i>.<b>value</b>([<i>value</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/pie.js)
+<a name="pie_value" href="#pie_value">#</a> <i>pie</i>.<b>value</b>([<i>value</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/pie.js)
 
 If *value* is specified, sets the value accessor to the specified function or number and returns this pie generator. If *value* is not specified, returns the current value accessor, which defaults to:
 
@@ -286,7 +286,7 @@ const arcs = d3.pie()(data.map(d => d.number));
 
 The benefit of an accessor is that the input data remains associated with the returned objects, thereby making it easier to access other fields of the data, for example to set the color or to add text labels.
 
-<a name="pie_sort" href="#pie_sort">#</a> <i>pie</i>.<b>sort</b>([<i>compare</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/pie.js)
+<a name="pie_sort" href="#pie_sort">#</a> <i>pie</i>.<b>sort</b>([<i>compare</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/pie.js)
 
 If *compare* is specified, sets the data comparator to the specified function and returns this pie generator. If *compare* is not specified, returns the current data comparator, which defaults to null. If both the data comparator and the value comparator are null, then arcs are positioned in the original input order. Otherwise, the data is sorted according to the data comparator, and the resulting order is used. Setting the data comparator implicitly sets the [value comparator](#pie_sortValues) to null.
 
@@ -298,7 +298,7 @@ pie.sort((a, b) => a.name.localeCompare(b.name));
 
 Sorting does not affect the order of the [generated arc array](#_pie) which is always in the same order as the input data array; it merely affects the computed angles of each arc. The first arc starts at the [start angle](#pie_startAngle) and the last arc ends at the [end angle](#pie_endAngle).
 
-<a name="pie_sortValues" href="#pie_sortValues">#</a> <i>pie</i>.<b>sortValues</b>([<i>compare</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/pie.js)
+<a name="pie_sortValues" href="#pie_sortValues">#</a> <i>pie</i>.<b>sortValues</b>([<i>compare</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/pie.js)
 
 If *compare* is specified, sets the value comparator to the specified function and returns this pie generator. If *compare* is not specified, returns the current value comparator, which defaults to descending value. The default value comparator is implemented as:
 
@@ -318,7 +318,7 @@ pie.sortValues((a, b) => a - b);
 
 Sorting does not affect the order of the [generated arc array](#_pie) which is always in the same order as the input data array; it merely affects the computed angles of each arc. The first arc starts at the [start angle](#pie_startAngle) and the last arc ends at the [end angle](#pie_endAngle).
 
-<a name="pie_startAngle" href="#pie_startAngle">#</a> <i>pie</i>.<b>startAngle</b>([<i>angle</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/pie.js)
+<a name="pie_startAngle" href="#pie_startAngle">#</a> <i>pie</i>.<b>startAngle</b>([<i>angle</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/pie.js)
 
 If *angle* is specified, sets the overall start angle of the pie to the specified function or number and returns this pie generator. If *angle* is not specified, returns the current start angle accessor, which defaults to:
 
@@ -330,7 +330,7 @@ function startAngle() {
 
 The start angle here means the *overall* start angle of the pie, *i.e.*, the start angle of the first arc. The start angle accessor is invoked once, being passed the same arguments and `this` context as the [pie generator](#_pie). The units of *angle* are arbitrary, but if you plan to use the pie generator in conjunction with an [arc generator](#arcs), you should specify an angle in radians, with 0 at -*y* (12 o’clock) and positive angles proceeding clockwise.
 
-<a name="pie_endAngle" href="#pie_endAngle">#</a> <i>pie</i>.<b>endAngle</b>([<i>angle</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/pie.js)
+<a name="pie_endAngle" href="#pie_endAngle">#</a> <i>pie</i>.<b>endAngle</b>([<i>angle</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/pie.js)
 
 If *angle* is specified, sets the overall end angle of the pie to the specified function or number and returns this pie generator. If *angle* is not specified, returns the current end angle accessor, which defaults to:
 
@@ -344,7 +344,7 @@ The end angle here means the *overall* end angle of the pie, *i.e.*, the end ang
 
 The value of the end angle is constrained to [startAngle](#pie_startAngle) ± τ, such that |endAngle - startAngle| ≤ τ.
 
-<a name="pie_padAngle" href="#pie_padAngle">#</a> <i>pie</i>.<b>padAngle</b>([<i>angle</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/pie.js)
+<a name="pie_padAngle" href="#pie_padAngle">#</a> <i>pie</i>.<b>padAngle</b>([<i>angle</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/pie.js)
 
 If *angle* is specified, sets the pad angle to the specified function or number and returns this pie generator. If *angle* is not specified, returns the current pad angle accessor, which defaults to:
 
@@ -362,15 +362,15 @@ The pad angle here means the angular separation between each adjacent arc. The t
 
 The line generator produces a [spline](https://en.wikipedia.org/wiki/Spline_\(mathematics\)) or [polyline](https://en.wikipedia.org/wiki/Polygonal_chain), as in a line chart. Lines also appear in many other visualization types, such as the links in [hierarchical edge bundling](https://observablehq.com/@d3/hierarchical-edge-bundling).
 
-<a name="line" href="#line">#</a> d3.<b>line</b>([<i>x</i>][, <i>y</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/line.js), [Examples](https://observablehq.com/@d3/d3-line)
+<a name="line" href="#line">#</a> d3.<b>line</b>([<i>x</i>][, <i>y</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/line.js), [Examples](https://observablehq.com/@d3/d3-line)
 
 Constructs a new line generator with the default settings. If *x* or *y* are specified, sets the corresponding accessors to the specified function or number and returns this line generator.
 
-<a name="_line" href="#_line">#</a> <i>line</i>(<i>data</i>) · [Source](https://github.com/d3/d3-shape/blob/master/src/line.js), [Examples](https://observablehq.com/@d3/d3-line)
+<a name="_line" href="#_line">#</a> <i>line</i>(<i>data</i>) · [Source](https://github.com/d3/d3-shape/blob/main/src/line.js), [Examples](https://observablehq.com/@d3/d3-line)
 
 Generates a line for the given array of *data*. Depending on this line generator’s associated [curve](#line_curve), the given input *data* may need to be sorted by *x*-value before being passed to the line generator. If the line generator has a [context](#line_context), then the line is rendered to this context as a sequence of [path method](http://www.w3.org/TR/2dcontext/#canvaspathmethods) calls and this function returns void. Otherwise, a [path data](http://www.w3.org/TR/SVG/paths.html#PathData) string is returned.
 
-<a name="line_x" href="#line_x">#</a> <i>line</i>.<b>x</b>([<i>x</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/line.js), [Examples](https://observablehq.com/@d3/d3-line)
+<a name="line_x" href="#line_x">#</a> <i>line</i>.<b>x</b>([<i>x</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/line.js), [Examples](https://observablehq.com/@d3/d3-line)
 
 If *x* is specified, sets the x accessor to the specified function or number and returns this line generator. If *x* is not specified, returns the current x accessor, which defaults to:
 
@@ -398,7 +398,7 @@ const line = d3.line()
     .y(d => y(d.value));
 ```
 
-<a name="line_y" href="#line_y">#</a> <i>line</i>.<b>y</b>([<i>y</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/line.js), [Examples](https://observablehq.com/@d3/d3-line)
+<a name="line_y" href="#line_y">#</a> <i>line</i>.<b>y</b>([<i>y</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/line.js), [Examples](https://observablehq.com/@d3/d3-line)
 
 If *y* is specified, sets the y accessor to the specified function or number and returns this line generator. If *y* is not specified, returns the current y accessor, which defaults to:
 
@@ -410,7 +410,7 @@ function y(d) {
 
 When a line is [generated](#_line), the y accessor will be invoked for each [defined](#line_defined) element in the input data array, being passed the element `d`, the index `i`, and the array `data` as three arguments. The default y accessor assumes that the input data are two-element arrays of numbers. See [*line*.x](#line_x) for more information.
 
-<a name="line_defined" href="#line_defined">#</a> <i>line</i>.<b>defined</b>([<i>defined</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/line.js), [Examples](https://observablehq.com/@d3/d3-line)
+<a name="line_defined" href="#line_defined">#</a> <i>line</i>.<b>defined</b>([<i>defined</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/line.js), [Examples](https://observablehq.com/@d3/d3-line)
 
 If *defined* is specified, sets the defined accessor to the specified function or boolean and returns this line generator. If *defined* is not specified, returns the current defined accessor, which defaults to:
 
@@ -426,29 +426,29 @@ The default accessor thus assumes that the input data is always defined. When a 
 
 Note that if a line segment consists of only a single point, it may appear invisible unless rendered with rounded or square [line caps](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-linecap). In addition, some curves such as [curveCardinalOpen](#curveCardinalOpen) only render a visible segment if it contains multiple points.
 
-<a name="line_curve" href="#line_curve">#</a> <i>line</i>.<b>curve</b>([<i>curve</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/line.js), [Examples](https://observablehq.com/@d3/d3-line)
+<a name="line_curve" href="#line_curve">#</a> <i>line</i>.<b>curve</b>([<i>curve</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/line.js), [Examples](https://observablehq.com/@d3/d3-line)
 
 If *curve* is specified, sets the [curve factory](#curves) and returns this line generator. If *curve* is not specified, returns the current curve factory, which defaults to [curveLinear](#curveLinear).
 
-<a name="line_context" href="#line_context">#</a> <i>line</i>.<b>context</b>([<i>context</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/line.js), [Examples](https://observablehq.com/@d3/d3-line)
+<a name="line_context" href="#line_context">#</a> <i>line</i>.<b>context</b>([<i>context</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/line.js), [Examples](https://observablehq.com/@d3/d3-line)
 
 If *context* is specified, sets the context and returns this line generator. If *context* is not specified, returns the current context, which defaults to null. If the context is not null, then the [generated line](#_line) is rendered to this context as a sequence of [path method](http://www.w3.org/TR/2dcontext/#canvaspathmethods) calls. Otherwise, a [path data](http://www.w3.org/TR/SVG/paths.html#PathData) string representing the generated line is returned.
 
-<a name="lineRadial" href="#lineRadial">#</a> d3.<b>lineRadial</b>() · [Source](https://github.com/d3/d3-shape/blob/master/src/lineRadial.js), [Examples](https://observablehq.com/@d3/d3-lineradial)
+<a name="lineRadial" href="#lineRadial">#</a> d3.<b>lineRadial</b>() · [Source](https://github.com/d3/d3-shape/blob/main/src/lineRadial.js), [Examples](https://observablehq.com/@d3/d3-lineradial)
 
 <img alt="Radial Line" width="250" height="250" src="https://raw.githubusercontent.com/d3/d3-shape/master/img/line-radial.png">
 
 Constructs a new radial line generator with the default settings. A radial line generator is equivalent to the standard Cartesian [line generator](#line), except the [x](#line_x) and [y](#line_y) accessors are replaced with [angle](#lineRadial_angle) and [radius](#lineRadial_radius) accessors. Radial lines are always positioned relative to ⟨0,0⟩; use a transform (see: [SVG](http://www.w3.org/TR/SVG/coords.html#TransformAttribute), [Canvas](http://www.w3.org/TR/2dcontext/#transformations)) to change the origin.
 
-<a name="_lineRadial" href="#_lineRadial">#</a> <i>lineRadial</i>(<i>data</i>) · [Source](https://github.com/d3/d3-shape/blob/master/src/lineRadial.js#L4), [Examples](https://observablehq.com/@d3/d3-lineradial)
+<a name="_lineRadial" href="#_lineRadial">#</a> <i>lineRadial</i>(<i>data</i>) · [Source](https://github.com/d3/d3-shape/blob/main/src/lineRadial.js#L4), [Examples](https://observablehq.com/@d3/d3-lineradial)
 
 Equivalent to [*line*](#_line).
 
-<a name="lineRadial_angle" href="#lineRadial_angle">#</a> <i>lineRadial</i>.<b>angle</b>([<i>angle</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/lineRadial.js#L7), [Examples](https://observablehq.com/@d3/d3-lineradial)
+<a name="lineRadial_angle" href="#lineRadial_angle">#</a> <i>lineRadial</i>.<b>angle</b>([<i>angle</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/lineRadial.js#L7), [Examples](https://observablehq.com/@d3/d3-lineradial)
 
 Equivalent to [*line*.x](#line_x), except the accessor returns the angle in radians, with 0 at -*y* (12 o’clock).
 
-<a name="lineRadial_radius" href="#lineRadial_radius">#</a> <i>lineRadial</i>.<b>radius</b>([<i>radius</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/lineRadial.js#L8), [Examples](https://observablehq.com/@d3/d3-lineradial)
+<a name="lineRadial_radius" href="#lineRadial_radius">#</a> <i>lineRadial</i>.<b>radius</b>([<i>radius</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/lineRadial.js#L8), [Examples](https://observablehq.com/@d3/d3-lineradial)
 
 Equivalent to [*line*.y](#line_y), except the accessor returns the radius: the distance from the origin ⟨0,0⟩.
 
@@ -456,7 +456,7 @@ Equivalent to [*line*.y](#line_y), except the accessor returns the radius: the d
 
 Equivalent to [*line*.defined](#line_defined).
 
-<a name="lineRadial_curve" href="#lineRadial_curve">#</a> <i>lineRadial</i>.<b>curve</b>([<i>curve</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/lineRadial.js), [Examples](https://observablehq.com/@d3/d3-lineradial)
+<a name="lineRadial_curve" href="#lineRadial_curve">#</a> <i>lineRadial</i>.<b>curve</b>([<i>curve</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/lineRadial.js), [Examples](https://observablehq.com/@d3/d3-lineradial)
 
 Equivalent to [*line*.curve](#line_curve). Note that [curveMonotoneX](#curveMonotoneX) or [curveMonotoneY](#curveMonotoneY) are not recommended for radial lines because they assume that the data is monotonic in *x* or *y*, which is typically untrue of radial lines.
 
@@ -470,19 +470,19 @@ Equivalent to [*line*.context](#line_context).
 
 The area generator produces an area, as in an area chart. An area is defined by two bounding [lines](#lines), either splines or polylines. Typically, the two lines share the same [*x*-values](#area_x) ([x0](#area_x0) = [x1](#area_x1)), differing only in *y*-value ([y0](#area_y0) and [y1](#area_y1)); most commonly, y0 is defined as a constant representing [zero](http://www.vox.com/2015/11/19/9758062/y-axis-zero-chart). The first line (the <i>topline</i>) is defined by x1 and y1 and is rendered first; the second line (the <i>baseline</i>) is defined by x0 and y0 and is rendered second, with the points in reverse order. With a [curveLinear](#curveLinear) [curve](#area_curve), this produces a clockwise polygon.
 
-<a name="area" href="#area">#</a> d3.<b>area</b>([<i>x</i>][, <i>y0</i>][, <i>y1</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/area.js)
+<a name="area" href="#area">#</a> d3.<b>area</b>([<i>x</i>][, <i>y0</i>][, <i>y1</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/area.js)
 
 Constructs a new area generator with the default settings. If *x*, *y0* or *y1* are specified, sets the corresponding accessors to the specified function or number and returns this area generator.
 
-<a name="_area" href="#_area">#</a> <i>area</i>(<i>data</i>) · [Source](https://github.com/d3/d3-shape/blob/master/src/area.js)
+<a name="_area" href="#_area">#</a> <i>area</i>(<i>data</i>) · [Source](https://github.com/d3/d3-shape/blob/main/src/area.js)
 
 Generates an area for the given array of *data*. Depending on this area generator’s associated [curve](#area_curve), the given input *data* may need to be sorted by *x*-value before being passed to the area generator. If the area generator has a [context](#line_context), then the area is rendered to this context as a sequence of [path method](http://www.w3.org/TR/2dcontext/#canvaspathmethods) calls and this function returns void. Otherwise, a [path data](http://www.w3.org/TR/SVG/paths.html#PathData) string is returned.
 
-<a name="area_x" href="#area_x">#</a> <i>area</i>.<b>x</b>([<i>x</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/area.js)
+<a name="area_x" href="#area_x">#</a> <i>area</i>.<b>x</b>([<i>x</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/area.js)
 
 If *x* is specified, sets [x0](#area_x0) to *x* and [x1](#area_x1) to null and returns this area generator. If *x* is not specified, returns the current x0 accessor.
 
-<a name="area_x0" href="#area_x0">#</a> <i>area</i>.<b>x0</b>([<i>x</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/area.js)
+<a name="area_x0" href="#area_x0">#</a> <i>area</i>.<b>x0</b>([<i>x</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/area.js)
 
 If *x* is specified, sets the x0 accessor to the specified function or number and returns this area generator. If *x* is not specified, returns the current x0 accessor, which defaults to:
 
@@ -511,17 +511,17 @@ const area = d3.area()
     .y0(y(0));
 ```
 
-<a name="area_x1" href="#area_x1">#</a> <i>area</i>.<b>x1</b>([<i>x</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/area.js)
+<a name="area_x1" href="#area_x1">#</a> <i>area</i>.<b>x1</b>([<i>x</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/area.js)
 
 If *x* is specified, sets the x1 accessor to the specified function or number and returns this area generator. If *x* is not specified, returns the current x1 accessor, which defaults to null, indicating that the previously-computed [x0](#area_x0) value should be reused for the x1 value.
 
 When an area is [generated](#_area), the x1 accessor will be invoked for each [defined](#area_defined) element in the input data array, being passed the element `d`, the index `i`, and the array `data` as three arguments. See [*area*.x0](#area_x0) for more information.
 
-<a name="area_y" href="#area_y">#</a> <i>area</i>.<b>y</b>([<i>y</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/area.js)
+<a name="area_y" href="#area_y">#</a> <i>area</i>.<b>y</b>([<i>y</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/area.js)
 
 If *y* is specified, sets [y0](#area_y0) to *y* and [y1](#area_y1) to null and returns this area generator. If *y* is not specified, returns the current y0 accessor.
 
-<a name="area_y0" href="#area_y0">#</a> <i>area</i>.<b>y0</b>([<i>y</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/area.js)
+<a name="area_y0" href="#area_y0">#</a> <i>area</i>.<b>y0</b>([<i>y</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/area.js)
 
 If *y* is specified, sets the y0 accessor to the specified function or number and returns this area generator. If *y* is not specified, returns the current y0 accessor, which defaults to:
 
@@ -533,7 +533,7 @@ function y() {
 
 When an area is [generated](#_area), the y0 accessor will be invoked for each [defined](#area_defined) element in the input data array, being passed the element `d`, the index `i`, and the array `data` as three arguments. See [*area*.x0](#area_x0) for more information.
 
-<a name="area_y1" href="#area_y1">#</a> <i>area</i>.<b>y1</b>([<i>y</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/area.js)
+<a name="area_y1" href="#area_y1">#</a> <i>area</i>.<b>y1</b>([<i>y</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/area.js)
 
 If *y* is specified, sets the y1 accessor to the specified function or number and returns this area generator. If *y* is not specified, returns the current y1 accessor, which defaults to:
 
@@ -545,7 +545,7 @@ function y(d) {
 
 A null accessor is also allowed, indicating that the previously-computed [y0](#area_y0) value should be reused for the y1 value. When an area is [generated](#_area), the y1 accessor will be invoked for each [defined](#area_defined) element in the input data array, being passed the element `d`, the index `i`, and the array `data` as three arguments. See [*area*.x0](#area_x0) for more information.
 
-<a name="area_defined" href="#area_defined">#</a> <i>area</i>.<b>defined</b>([<i>defined</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/area.js)
+<a name="area_defined" href="#area_defined">#</a> <i>area</i>.<b>defined</b>([<i>defined</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/area.js)
 
 If *defined* is specified, sets the defined accessor to the specified function or boolean and returns this area generator. If *defined* is not specified, returns the current defined accessor, which defaults to:
 
@@ -561,28 +561,28 @@ The default accessor thus assumes that the input data is always defined. When an
 
 Note that if an area segment consists of only a single point, it may appear invisible unless rendered with rounded or square [line caps](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-linecap). In addition, some curves such as [curveCardinalOpen](#curveCardinalOpen) only render a visible segment if it contains multiple points.
 
-<a name="area_curve" href="#area_curve">#</a> <i>area</i>.<b>curve</b>([<i>curve</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/area.js)
+<a name="area_curve" href="#area_curve">#</a> <i>area</i>.<b>curve</b>([<i>curve</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/area.js)
 
 If *curve* is specified, sets the [curve factory](#curves) and returns this area generator. If *curve* is not specified, returns the current curve factory, which defaults to [curveLinear](#curveLinear).
 
-<a name="area_context" href="#area_context">#</a> <i>area</i>.<b>context</b>([<i>context</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/area.js)
+<a name="area_context" href="#area_context">#</a> <i>area</i>.<b>context</b>([<i>context</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/area.js)
 
 If *context* is specified, sets the context and returns this area generator. If *context* is not specified, returns the current context, which defaults to null. If the context is not null, then the [generated area](#_area) is rendered to this context as a sequence of [path method](http://www.w3.org/TR/2dcontext/#canvaspathmethods) calls. Otherwise, a [path data](http://www.w3.org/TR/SVG/paths.html#PathData) string representing the generated area is returned.
 
-<a name="area_lineX0" href="#area_lineX0">#</a> <i>area</i>.<b>lineX0</b>() · [Source](https://github.com/d3/d3-shape/blob/master/src/area.js)
-<br><a name="area_lineY0" href="#area_lineY0">#</a> <i>area</i>.<b>lineY0</b>() · [Source](https://github.com/d3/d3-shape/blob/master/src/area.js)
+<a name="area_lineX0" href="#area_lineX0">#</a> <i>area</i>.<b>lineX0</b>() · [Source](https://github.com/d3/d3-shape/blob/main/src/area.js)
+<br><a name="area_lineY0" href="#area_lineY0">#</a> <i>area</i>.<b>lineY0</b>() · [Source](https://github.com/d3/d3-shape/blob/main/src/area.js)
 
 Returns a new [line generator](#lines) that has this area generator’s current [defined accessor](#area_defined), [curve](#area_curve) and [context](#area_context). The line’s [*x*-accessor](#line_x) is this area’s [*x0*-accessor](#area_x0), and the line’s [*y*-accessor](#line_y) is this area’s [*y0*-accessor](#area_y0).
 
-<a name="area_lineX1" href="#area_lineX1">#</a> <i>area</i>.<b>lineX1</b>() · [Source](https://github.com/d3/d3-shape/blob/master/src/area.js)
+<a name="area_lineX1" href="#area_lineX1">#</a> <i>area</i>.<b>lineX1</b>() · [Source](https://github.com/d3/d3-shape/blob/main/src/area.js)
 
 Returns a new [line generator](#lines) that has this area generator’s current [defined accessor](#area_defined), [curve](#area_curve) and [context](#area_context). The line’s [*x*-accessor](#line_x) is this area’s [*x1*-accessor](#area_x1), and the line’s [*y*-accessor](#line_y) is this area’s [*y0*-accessor](#area_y0).
 
-<a name="area_lineY1" href="#area_lineY1">#</a> <i>area</i>.<b>lineY1</b>() · [Source](https://github.com/d3/d3-shape/blob/master/src/area.js)
+<a name="area_lineY1" href="#area_lineY1">#</a> <i>area</i>.<b>lineY1</b>() · [Source](https://github.com/d3/d3-shape/blob/main/src/area.js)
 
 Returns a new [line generator](#lines) that has this area generator’s current [defined accessor](#area_defined), [curve](#area_curve) and [context](#area_context). The line’s [*x*-accessor](#line_x) is this area’s [*x0*-accessor](#area_x0), and the line’s [*y*-accessor](#line_y) is this area’s [*y1*-accessor](#area_y1).
 
-<a name="areaRadial" href="#areaRadial">#</a> d3.<b>areaRadial</b>() · [Source](https://github.com/d3/d3-shape/blob/master/src/areaRadial.js)
+<a name="areaRadial" href="#areaRadial">#</a> d3.<b>areaRadial</b>() · [Source](https://github.com/d3/d3-shape/blob/main/src/areaRadial.js)
 
 <img alt="Radial Area" width="250" height="250" src="https://raw.githubusercontent.com/d3/d3-shape/master/img/area-radial.png">
 
@@ -592,27 +592,27 @@ Constructs a new radial area generator with the default settings. A radial area 
 
 Equivalent to [*area*](#_area).
 
-<a name="areaRadial_angle" href="#areaRadial_angle">#</a> <i>areaRadial</i>.<b>angle</b>([<i>angle</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/areaRadial.js)
+<a name="areaRadial_angle" href="#areaRadial_angle">#</a> <i>areaRadial</i>.<b>angle</b>([<i>angle</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/areaRadial.js)
 
 Equivalent to [*area*.x](#area_x), except the accessor returns the angle in radians, with 0 at -*y* (12 o’clock).
 
-<a name="areaRadial_startAngle" href="#areaRadial_startAngle">#</a> <i>areaRadial</i>.<b>startAngle</b>([<i>angle</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/areaRadial.js)
+<a name="areaRadial_startAngle" href="#areaRadial_startAngle">#</a> <i>areaRadial</i>.<b>startAngle</b>([<i>angle</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/areaRadial.js)
 
 Equivalent to [*area*.x0](#area_x0), except the accessor returns the angle in radians, with 0 at -*y* (12 o’clock). Note: typically [angle](#areaRadial_angle) is used instead of setting separate start and end angles.
 
-<a name="areaRadial_endAngle" href="#areaRadial_endAngle">#</a> <i>areaRadial</i>.<b>endAngle</b>([<i>angle</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/areaRadial.js)
+<a name="areaRadial_endAngle" href="#areaRadial_endAngle">#</a> <i>areaRadial</i>.<b>endAngle</b>([<i>angle</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/areaRadial.js)
 
 Equivalent to [*area*.x1](#area_x1), except the accessor returns the angle in radians, with 0 at -*y* (12 o’clock). Note: typically [angle](#areaRadial_angle) is used instead of setting separate start and end angles.
 
-<a name="areaRadial_radius" href="#areaRadial_radius">#</a> <i>areaRadial</i>.<b>radius</b>([<i>radius</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/areaRadial.js)
+<a name="areaRadial_radius" href="#areaRadial_radius">#</a> <i>areaRadial</i>.<b>radius</b>([<i>radius</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/areaRadial.js)
 
 Equivalent to [*area*.y](#area_y), except the accessor returns the radius: the distance from the origin ⟨0,0⟩.
 
-<a name="areaRadial_innerRadius" href="#areaRadial_innerRadius">#</a> <i>areaRadial</i>.<b>innerRadius</b>([<i>radius</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/areaRadial.js)
+<a name="areaRadial_innerRadius" href="#areaRadial_innerRadius">#</a> <i>areaRadial</i>.<b>innerRadius</b>([<i>radius</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/areaRadial.js)
 
 Equivalent to [*area*.y0](#area_y0), except the accessor returns the radius: the distance from the origin ⟨0,0⟩.
 
-<a name="areaRadial_outerRadius" href="#areaRadial_outerRadius">#</a> <i>areaRadial</i>.<b>outerRadius</b>([<i>radius</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/areaRadial.js)
+<a name="areaRadial_outerRadius" href="#areaRadial_outerRadius">#</a> <i>areaRadial</i>.<b>outerRadius</b>([<i>radius</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/areaRadial.js)
 
 Equivalent to [*area*.y1](#area_y1), except the accessor returns the radius: the distance from the origin ⟨0,0⟩.
 
@@ -620,7 +620,7 @@ Equivalent to [*area*.y1](#area_y1), except the accessor returns the radius: the
 
 Equivalent to [*area*.defined](#area_defined).
 
-<a name="areaRadial_curve" href="#areaRadial_curve">#</a> <i>areaRadial</i>.<b>curve</b>([<i>curve</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/areaRadial.js)
+<a name="areaRadial_curve" href="#areaRadial_curve">#</a> <i>areaRadial</i>.<b>curve</b>([<i>curve</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/areaRadial.js)
 
 Equivalent to [*area*.curve](#area_curve). Note that [curveMonotoneX](#curveMonotoneX) or [curveMonotoneY](#curveMonotoneY) are not recommended for radial areas because they assume that the data is monotonic in *x* or *y*, which is typically untrue of radial areas.
 
@@ -628,16 +628,16 @@ Equivalent to [*area*.curve](#area_curve). Note that [curveMonotoneX](#curveMono
 
 Equivalent to [*line*.context](#line_context).
 
-<a name="areaRadial_lineStartAngle" href="#areaRadial_lineStartAngle">#</a> <i>areaRadial</i>.<b>lineStartAngle</b>() · [Source](https://github.com/d3/d3-shape/blob/master/src/areaRadial.js)
-<br><a name="areaRadial_lineInnerRadius" href="#areaRadial_lineInnerRadius">#</a> <i>areaRadial</i>.<b>lineInnerRadius</b>() · [Source](https://github.com/d3/d3-shape/blob/master/src/areaRadial.js)
+<a name="areaRadial_lineStartAngle" href="#areaRadial_lineStartAngle">#</a> <i>areaRadial</i>.<b>lineStartAngle</b>() · [Source](https://github.com/d3/d3-shape/blob/main/src/areaRadial.js)
+<br><a name="areaRadial_lineInnerRadius" href="#areaRadial_lineInnerRadius">#</a> <i>areaRadial</i>.<b>lineInnerRadius</b>() · [Source](https://github.com/d3/d3-shape/blob/main/src/areaRadial.js)
 
 Returns a new [radial line generator](#lineRadial) that has this radial area generator’s current [defined accessor](#areaRadial_defined), [curve](#areaRadial_curve) and [context](#areaRadial_context). The line’s [angle accessor](#lineRadial_angle) is this area’s [start angle accessor](#areaRadial_startAngle), and the line’s [radius accessor](#lineRadial_radius) is this area’s [inner radius accessor](#areaRadial_innerRadius).
 
-<a name="areaRadial_lineEndAngle" href="#areaRadial_lineEndAngle">#</a> <i>areaRadial</i>.<b>lineEndAngle</b>() · [Source](https://github.com/d3/d3-shape/blob/master/src/areaRadial.js)
+<a name="areaRadial_lineEndAngle" href="#areaRadial_lineEndAngle">#</a> <i>areaRadial</i>.<b>lineEndAngle</b>() · [Source](https://github.com/d3/d3-shape/blob/main/src/areaRadial.js)
 
 Returns a new [radial line generator](#lineRadial) that has this radial area generator’s current [defined accessor](#areaRadial_defined), [curve](#areaRadial_curve) and [context](#areaRadial_context). The line’s [angle accessor](#lineRadial_angle) is this area’s [end angle accessor](#areaRadial_endAngle), and the line’s [radius accessor](#lineRadial_radius) is this area’s [inner radius accessor](#areaRadial_innerRadius).
 
-<a name="areaRadial_lineOuterRadius" href="#areaRadial_lineOuterRadius">#</a> <i>areaRadial</i>.<b>lineOuterRadius</b>() · [Source](https://github.com/d3/d3-shape/blob/master/src/areaRadial.js)
+<a name="areaRadial_lineOuterRadius" href="#areaRadial_lineOuterRadius">#</a> <i>areaRadial</i>.<b>lineOuterRadius</b>() · [Source](https://github.com/d3/d3-shape/blob/main/src/areaRadial.js)
 
 Returns a new [radial line generator](#lineRadial) that has this radial area generator’s current [defined accessor](#areaRadial_defined), [curve](#areaRadial_curve) and [context](#areaRadial_context). The line’s [angle accessor](#lineRadial_angle) is this area’s [start angle accessor](#areaRadial_startAngle), and the line’s [radius accessor](#lineRadial_radius) is this area’s [outer radius accessor](#areaRadial_outerRadius).
 
@@ -652,43 +652,43 @@ const line = d3.line(d => d.date, d => d.value)
     .curve(d3.curveCatmullRom.alpha(0.5));
 ```
 
-<a name="curveBasis" href="#curveBasis">#</a> d3.<b>curveBasis</b>(<i>context</i>) · [Source](https://github.com/d3/d3-shape/blob/master/src/curve/basis.js)
+<a name="curveBasis" href="#curveBasis">#</a> d3.<b>curveBasis</b>(<i>context</i>) · [Source](https://github.com/d3/d3-shape/blob/main/src/curve/basis.js)
 
 <img src="https://raw.githubusercontent.com/d3/d3-shape/master/img/basis.png" width="888" height="240" alt="basis">
 
 Produces a cubic [basis spline](https://en.wikipedia.org/wiki/B-spline) using the specified control points. The first and last points are triplicated such that the spline starts at the first point and ends at the last point, and is tangent to the line between the first and second points, and to the line between the penultimate and last points.
 
-<a name="curveBasisClosed" href="#curveBasisClosed">#</a> d3.<b>curveBasisClosed</b>(<i>context</i>) · [Source](https://github.com/d3/d3-shape/blob/master/src/curve/basisClosed.js)
+<a name="curveBasisClosed" href="#curveBasisClosed">#</a> d3.<b>curveBasisClosed</b>(<i>context</i>) · [Source](https://github.com/d3/d3-shape/blob/main/src/curve/basisClosed.js)
 
 <img src="https://raw.githubusercontent.com/d3/d3-shape/master/img/basisClosed.png" width="888" height="240" alt="basisClosed">
 
 Produces a closed cubic [basis spline](https://en.wikipedia.org/wiki/B-spline) using the specified control points. When a line segment ends, the first three control points are repeated, producing a closed loop with C2 continuity.
 
-<a name="curveBasisOpen" href="#curveBasisOpen">#</a> d3.<b>curveBasisOpen</b>(<i>context</i>) · [Source](https://github.com/d3/d3-shape/blob/master/src/curve/basisOpen.js)
+<a name="curveBasisOpen" href="#curveBasisOpen">#</a> d3.<b>curveBasisOpen</b>(<i>context</i>) · [Source](https://github.com/d3/d3-shape/blob/main/src/curve/basisOpen.js)
 
 <img src="https://raw.githubusercontent.com/d3/d3-shape/master/img/basisOpen.png" width="888" height="240" alt="basisOpen">
 
 Produces a cubic [basis spline](https://en.wikipedia.org/wiki/B-spline) using the specified control points. Unlike [basis](#basis), the first and last points are not repeated, and thus the curve typically does not intersect these points.
 
-<a name="curveBumpX" href="#curveBumpX">#</a> d3.<b>curveBumpX</b>(<i>context</i>) · [Source](https://github.com/d3/d3-shape/blob/master/src/curve/bump.js)
+<a name="curveBumpX" href="#curveBumpX">#</a> d3.<b>curveBumpX</b>(<i>context</i>) · [Source](https://github.com/d3/d3-shape/blob/main/src/curve/bump.js)
 
 <img src="https://raw.githubusercontent.com/d3/d3-shape/master/img/bumpX.png" width="888" height="240" alt="bumpX">
 
 Produces a Bézier curve between each pair of points, with horizontal tangents at each point.
 
-<a name="curveBumpY" href="#curveBumpY">#</a> d3.<b>curveBumpY</b>(<i>context</i>) · [Source](https://github.com/d3/d3-shape/blob/master/src/curve/bump.js)
+<a name="curveBumpY" href="#curveBumpY">#</a> d3.<b>curveBumpY</b>(<i>context</i>) · [Source](https://github.com/d3/d3-shape/blob/main/src/curve/bump.js)
 
 <img src="https://raw.githubusercontent.com/d3/d3-shape/master/img/bumpY.png" width="888" height="240" alt="bumpY">
 
 Produces a Bézier curve between each pair of points, with vertical tangents at each point.
 
-<a name="curveBundle" href="#curveBundle">#</a> d3.<b>curveBundle</b>(<i>context</i>) · [Source](https://github.com/d3/d3-shape/blob/master/src/curve/bundle.js)
+<a name="curveBundle" href="#curveBundle">#</a> d3.<b>curveBundle</b>(<i>context</i>) · [Source](https://github.com/d3/d3-shape/blob/main/src/curve/bundle.js)
 
 <img src="https://raw.githubusercontent.com/d3/d3-shape/master/img/bundle.png" width="888" height="240" alt="bundle">
 
 Produces a straightened cubic [basis spline](https://en.wikipedia.org/wiki/B-spline) using the specified control points, with the spline straightened according to the curve’s [*beta*](#curveBundle_beta), which defaults to 0.85. This curve is typically used in [hierarchical edge bundling](https://observablehq.com/@d3/hierarchical-edge-bundling) to disambiguate connections, as proposed by [Danny Holten](https://www.win.tue.nl/vis1/home/dholten/) in [Hierarchical Edge Bundles: Visualization of Adjacency Relations in Hierarchical Data](https://www.win.tue.nl/vis1/home/dholten/papers/bundles_infovis.pdf). This curve does not implement [*curve*.areaStart](#curve_areaStart) and [*curve*.areaEnd](#curve_areaEnd); it is intended to work with [d3.line](#lines), not [d3.area](#areas).
 
-<a name="curveBundle_beta" href="#curveBundle_beta">#</a> <i>bundle</i>.<b>beta</b>(<i>beta</i>) · [Source](https://github.com/d3/d3-shape/blob/master/src/curve/bundle.js)
+<a name="curveBundle_beta" href="#curveBundle_beta">#</a> <i>bundle</i>.<b>beta</b>(<i>beta</i>) · [Source](https://github.com/d3/d3-shape/blob/main/src/curve/bundle.js)
 
 Returns a bundle curve with the specified *beta* in the range [0, 1], representing the bundle strength. If *beta* equals zero, a straight line between the first and last point is produced; if *beta* equals one, a standard [basis](#basis) spline is produced. For example:
 
@@ -696,25 +696,25 @@ Returns a bundle curve with the specified *beta* in the range [0, 1], representi
 const line = d3.line().curve(d3.curveBundle.beta(0.5));
 ```
 
-<a name="curveCardinal" href="#curveCardinal">#</a> d3.<b>curveCardinal</b>(<i>context</i>) · [Source](https://github.com/d3/d3-shape/blob/master/src/curve/cardinal.js)
+<a name="curveCardinal" href="#curveCardinal">#</a> d3.<b>curveCardinal</b>(<i>context</i>) · [Source](https://github.com/d3/d3-shape/blob/main/src/curve/cardinal.js)
 
 <img src="https://raw.githubusercontent.com/d3/d3-shape/master/img/cardinal.png" width="888" height="240" alt="cardinal">
 
 Produces a cubic [cardinal spline](https://en.wikipedia.org/wiki/Cubic_Hermite_spline#Cardinal_spline) using the specified control points, with one-sided differences used for the first and last piece. The default [tension](#curveCardinal_tension) is 0.
 
-<a name="curveCardinalClosed" href="#curveCardinalClosed">#</a> d3.<b>curveCardinalClosed</b>(<i>context</i>) · [Source](https://github.com/d3/d3-shape/blob/master/src/curve/cardinalClosed.js)
+<a name="curveCardinalClosed" href="#curveCardinalClosed">#</a> d3.<b>curveCardinalClosed</b>(<i>context</i>) · [Source](https://github.com/d3/d3-shape/blob/main/src/curve/cardinalClosed.js)
 
 <img src="https://raw.githubusercontent.com/d3/d3-shape/master/img/cardinalClosed.png" width="888" height="240" alt="cardinalClosed">
 
 Produces a closed cubic [cardinal spline](https://en.wikipedia.org/wiki/Cubic_Hermite_spline#Cardinal_spline) using the specified control points. When a line segment ends, the first three control points are repeated, producing a closed loop. The default [tension](#curveCardinal_tension) is 0.
 
-<a name="curveCardinalOpen" href="#curveCardinalOpen">#</a> d3.<b>curveCardinalOpen</b>(<i>context</i>) · [Source](https://github.com/d3/d3-shape/blob/master/src/curve/cardinalOpen.js)
+<a name="curveCardinalOpen" href="#curveCardinalOpen">#</a> d3.<b>curveCardinalOpen</b>(<i>context</i>) · [Source](https://github.com/d3/d3-shape/blob/main/src/curve/cardinalOpen.js)
 
 <img src="https://raw.githubusercontent.com/d3/d3-shape/master/img/cardinalOpen.png" width="888" height="240" alt="cardinalOpen">
 
 Produces a cubic [cardinal spline](https://en.wikipedia.org/wiki/Cubic_Hermite_spline#Cardinal_spline) using the specified control points. Unlike [curveCardinal](#curveCardinal), one-sided differences are not used for the first and last piece, and thus the curve starts at the second point and ends at the penultimate point. The default [tension](#curveCardinal_tension) is 0.
 
-<a name="curveCardinal_tension" href="#curveCardinal_tension">#</a> <i>cardinal</i>.<b>tension</b>(<i>tension</i>) · [Source](https://github.com/d3/d3-shape/blob/master/src/curve/cardinalOpen.js)
+<a name="curveCardinal_tension" href="#curveCardinal_tension">#</a> <i>cardinal</i>.<b>tension</b>(<i>tension</i>) · [Source](https://github.com/d3/d3-shape/blob/main/src/curve/cardinalOpen.js)
 
 Returns a cardinal curve with the specified *tension* in the range [0, 1]. The *tension* determines the length of the tangents: a *tension* of one yields all zero tangents, equivalent to [curveLinear](#curveLinear); a *tension* of zero produces a uniform [Catmull–Rom](#curveCatmullRom) spline. For example:
 
@@ -722,25 +722,25 @@ Returns a cardinal curve with the specified *tension* in the range [0, 1]. The *
 const line = d3.line().curve(d3.curveCardinal.tension(0.5));
 ```
 
-<a name="curveCatmullRom" href="#curveCatmullRom">#</a> d3.<b>curveCatmullRom</b>(<i>context</i>) · [Source](https://github.com/d3/d3-shape/blob/master/src/curve/catmullRom.js)
+<a name="curveCatmullRom" href="#curveCatmullRom">#</a> d3.<b>curveCatmullRom</b>(<i>context</i>) · [Source](https://github.com/d3/d3-shape/blob/main/src/curve/catmullRom.js)
 
 <img src="https://raw.githubusercontent.com/d3/d3-shape/master/img/catmullRom.png" width="888" height="240" alt="catmullRom">
 
 Produces a cubic Catmull–Rom spline using the specified control points and the parameter [*alpha*](#curveCatmullRom_alpha), which defaults to 0.5, as proposed by Yuksel et al. in [On the Parameterization of Catmull–Rom Curves](http://www.cemyuksel.com/research/catmullrom_param/), with one-sided differences used for the first and last piece.
 
-<a name="curveCatmullRomClosed" href="#curveCatmullRomClosed">#</a> d3.<b>curveCatmullRomClosed</b>(<i>context</i>) · [Source](https://github.com/d3/d3-shape/blob/master/src/curve/catmullRomClosed.js)
+<a name="curveCatmullRomClosed" href="#curveCatmullRomClosed">#</a> d3.<b>curveCatmullRomClosed</b>(<i>context</i>) · [Source](https://github.com/d3/d3-shape/blob/main/src/curve/catmullRomClosed.js)
 
 <img src="https://raw.githubusercontent.com/d3/d3-shape/master/img/catmullRomClosed.png" width="888" height="330" alt="catmullRomClosed">
 
 Produces a closed cubic Catmull–Rom spline using the specified control points and the parameter [*alpha*](#curveCatmullRom_alpha), which defaults to 0.5, as proposed by Yuksel et al. When a line segment ends, the first three control points are repeated, producing a closed loop.
 
-<a name="curveCatmullRomOpen" href="#curveCatmullRomOpen">#</a> d3.<b>curveCatmullRomOpen</b>(<i>context</i>) · [Source](https://github.com/d3/d3-shape/blob/master/src/curve/catmullRomOpen.js)
+<a name="curveCatmullRomOpen" href="#curveCatmullRomOpen">#</a> d3.<b>curveCatmullRomOpen</b>(<i>context</i>) · [Source](https://github.com/d3/d3-shape/blob/main/src/curve/catmullRomOpen.js)
 
 <img src="https://raw.githubusercontent.com/d3/d3-shape/master/img/catmullRomOpen.png" width="888" height="240" alt="catmullRomOpen">
 
 Produces a cubic Catmull–Rom spline using the specified control points and the parameter [*alpha*](#curveCatmullRom_alpha), which defaults to 0.5, as proposed by Yuksel et al. Unlike [curveCatmullRom](#curveCatmullRom), one-sided differences are not used for the first and last piece, and thus the curve starts at the second point and ends at the penultimate point.
 
-<a name="curveCatmullRom_alpha" href="#curveCatmullRom_alpha">#</a> <i>catmullRom</i>.<b>alpha</b>(<i>alpha</i>) · [Source](https://github.com/d3/d3-shape/blob/master/src/curve/catmullRom.js)
+<a name="curveCatmullRom_alpha" href="#curveCatmullRom_alpha">#</a> <i>catmullRom</i>.<b>alpha</b>(<i>alpha</i>) · [Source](https://github.com/d3/d3-shape/blob/main/src/curve/catmullRom.js)
 
 Returns a cubic Catmull–Rom curve with the specified *alpha* in the range [0, 1]. If *alpha* is zero, produces a uniform spline, equivalent to [curveCardinal](#curveCardinal) with a tension of zero; if *alpha* is one, produces a chordal spline; if *alpha* is 0.5, produces a [centripetal spline](https://en.wikipedia.org/wiki/Centripetal_Catmull–Rom_spline). Centripetal splines are recommended to avoid self-intersections and overshoot. For example:
 
@@ -748,49 +748,49 @@ Returns a cubic Catmull–Rom curve with the specified *alpha* in the range [0, 
 const line = d3.line().curve(d3.curveCatmullRom.alpha(0.5));
 ```
 
-<a name="curveLinear" href="#curveLinear">#</a> d3.<b>curveLinear</b>(<i>context</i>) · [Source](https://github.com/d3/d3-shape/blob/master/src/curve/linear.js)
+<a name="curveLinear" href="#curveLinear">#</a> d3.<b>curveLinear</b>(<i>context</i>) · [Source](https://github.com/d3/d3-shape/blob/main/src/curve/linear.js)
 
 <img src="https://raw.githubusercontent.com/d3/d3-shape/master/img/linear.png" width="888" height="240" alt="linear">
 
 Produces a polyline through the specified points.
 
-<a name="curveLinearClosed" href="#curveLinearClosed">#</a> d3.<b>curveLinearClosed</b>(<i>context</i>) · [Source](https://github.com/d3/d3-shape/blob/master/src/curve/linearClosed.js)
+<a name="curveLinearClosed" href="#curveLinearClosed">#</a> d3.<b>curveLinearClosed</b>(<i>context</i>) · [Source](https://github.com/d3/d3-shape/blob/main/src/curve/linearClosed.js)
 
 <img src="https://raw.githubusercontent.com/d3/d3-shape/master/img/linearClosed.png" width="888" height="240" alt="linearClosed">
 
 Produces a closed polyline through the specified points by repeating the first point when the line segment ends.
 
-<a name="curveMonotoneX" href="#curveMonotoneX">#</a> d3.<b>curveMonotoneX</b>(<i>context</i>) · [Source](https://github.com/d3/d3-shape/blob/master/src/curve/monotone.js)
+<a name="curveMonotoneX" href="#curveMonotoneX">#</a> d3.<b>curveMonotoneX</b>(<i>context</i>) · [Source](https://github.com/d3/d3-shape/blob/main/src/curve/monotone.js)
 
 <img src="https://raw.githubusercontent.com/d3/d3-shape/master/img/monotoneX.png" width="888" height="240" alt="monotoneX">
 
 Produces a cubic spline that [preserves monotonicity](https://en.wikipedia.org/wiki/Monotone_cubic_interpolation) in *y*, assuming monotonicity in *x*, as proposed by Steffen in [A simple method for monotonic interpolation in one dimension](http://adsabs.harvard.edu/full/1990A%26A...239..443S): “a smooth curve with continuous first-order derivatives that passes through any given set of data points without spurious oscillations. Local extrema can occur only at grid points where they are given by the data, but not in between two adjacent grid points.”
 
-<a name="curveMonotoneY" href="#curveMonotoneY">#</a> d3.<b>curveMonotoneY</b>(<i>context</i>) · [Source](https://github.com/d3/d3-shape/blob/master/src/curve/monotone.js)
+<a name="curveMonotoneY" href="#curveMonotoneY">#</a> d3.<b>curveMonotoneY</b>(<i>context</i>) · [Source](https://github.com/d3/d3-shape/blob/main/src/curve/monotone.js)
 
 <img src="https://raw.githubusercontent.com/d3/d3-shape/master/img/monotoneY.png" width="888" height="240" alt="monotoneY">
 
 Produces a cubic spline that [preserves monotonicity](https://en.wikipedia.org/wiki/Monotone_cubic_interpolation) in *x*, assuming monotonicity in *y*, as proposed by Steffen in [A simple method for monotonic interpolation in one dimension](http://adsabs.harvard.edu/full/1990A%26A...239..443S): “a smooth curve with continuous first-order derivatives that passes through any given set of data points without spurious oscillations. Local extrema can occur only at grid points where they are given by the data, but not in between two adjacent grid points.”
 
-<a name="curveNatural" href="#curveNatural">#</a> d3.<b>curveNatural</b>(<i>context</i>) · [Source](https://github.com/d3/d3-shape/blob/master/src/curve/natural.js)
+<a name="curveNatural" href="#curveNatural">#</a> d3.<b>curveNatural</b>(<i>context</i>) · [Source](https://github.com/d3/d3-shape/blob/main/src/curve/natural.js)
 
 <img src="https://raw.githubusercontent.com/d3/d3-shape/master/img/natural.png" width="888" height="240" alt="natural">
 
 Produces a [natural](https://en.wikipedia.org/wiki/Spline_interpolation) [cubic spline](http://mathworld.wolfram.com/CubicSpline.html) with the second derivative of the spline set to zero at the endpoints.
 
-<a name="curveStep" href="#curveStep">#</a> d3.<b>curveStep</b>(<i>context</i>) · [Source](https://github.com/d3/d3-shape/blob/master/src/curve/step.js)
+<a name="curveStep" href="#curveStep">#</a> d3.<b>curveStep</b>(<i>context</i>) · [Source](https://github.com/d3/d3-shape/blob/main/src/curve/step.js)
 
 <img src="https://raw.githubusercontent.com/d3/d3-shape/master/img/step.png" width="888" height="240" alt="step">
 
 Produces a piecewise constant function (a [step function](https://en.wikipedia.org/wiki/Step_function)) consisting of alternating horizontal and vertical lines. The *y*-value changes at the midpoint of each pair of adjacent *x*-values.
 
-<a name="curveStepAfter" href="#curveStepAfter">#</a> d3.<b>curveStepAfter</b>(<i>context</i>) · [Source](https://github.com/d3/d3-shape/blob/master/src/curve/step.js)
+<a name="curveStepAfter" href="#curveStepAfter">#</a> d3.<b>curveStepAfter</b>(<i>context</i>) · [Source](https://github.com/d3/d3-shape/blob/main/src/curve/step.js)
 
 <img src="https://raw.githubusercontent.com/d3/d3-shape/master/img/stepAfter.png" width="888" height="240" alt="stepAfter">
 
 Produces a piecewise constant function (a [step function](https://en.wikipedia.org/wiki/Step_function)) consisting of alternating horizontal and vertical lines. The *y*-value changes after the *x*-value.
 
-<a name="curveStepBefore" href="#curveStepBefore">#</a> d3.<b>curveStepBefore</b>(<i>context</i>) · [Source](https://github.com/d3/d3-shape/blob/master/src/curve/step.js)
+<a name="curveStepBefore" href="#curveStepBefore">#</a> d3.<b>curveStepBefore</b>(<i>context</i>) · [Source](https://github.com/d3/d3-shape/blob/main/src/curve/step.js)
 
 <img src="https://raw.githubusercontent.com/d3/d3-shape/master/img/stepBefore.png" width="888" height="240" alt="stepBefore">
 
@@ -800,23 +800,23 @@ Produces a piecewise constant function (a [step function](https://en.wikipedia.o
 
 Curves are typically not used directly, instead being passed to [*line*.curve](#line_curve) and [*area*.curve](#area_curve). However, you can define your own curve implementation should none of the built-in curves satisfy your needs using the following interface. You can also use this low-level interface with a built-in curve type as an alternative to the line and area generators.
 
-<a name="curve_areaStart" href="#curve_areaStart">#</a> <i>curve</i>.<b>areaStart</b>() · [Source](https://github.com/d3/d3-shape/blob/master/src/curve/step.js#L7)
+<a name="curve_areaStart" href="#curve_areaStart">#</a> <i>curve</i>.<b>areaStart</b>() · [Source](https://github.com/d3/d3-shape/blob/main/src/curve/step.js#L7)
 
 Indicates the start of a new area segment. Each area segment consists of exactly two [line segments](#curve_lineStart): the topline, followed by the baseline, with the baseline points in reverse order.
 
-<a name="curve_areaEnd" href="#curve_areaEnd">#</a> <i>curve</i>.<b>areaEnd</b>() · [Source](https://github.com/d3/d3-shape/blob/master/src/curve/step.js)
+<a name="curve_areaEnd" href="#curve_areaEnd">#</a> <i>curve</i>.<b>areaEnd</b>() · [Source](https://github.com/d3/d3-shape/blob/main/src/curve/step.js)
 
 Indicates the end of the current area segment.
 
-<a name="curve_lineStart" href="#curve_lineStart">#</a> <i>curve</i>.<b>lineStart</b>() · [Source](https://github.com/d3/d3-shape/blob/master/src/curve/step.js)
+<a name="curve_lineStart" href="#curve_lineStart">#</a> <i>curve</i>.<b>lineStart</b>() · [Source](https://github.com/d3/d3-shape/blob/main/src/curve/step.js)
 
 Indicates the start of a new line segment. Zero or more [points](#curve_point) will follow.
 
-<a name="curve_lineEnd" href="#curve_lineEnd">#</a> <i>curve</i>.<b>lineEnd</b>() · [Source](https://github.com/d3/d3-shape/blob/master/src/curve/step.js)
+<a name="curve_lineEnd" href="#curve_lineEnd">#</a> <i>curve</i>.<b>lineEnd</b>() · [Source](https://github.com/d3/d3-shape/blob/main/src/curve/step.js)
 
 Indicates the end of the current line segment.
 
-<a name="curve_point" href="#curve_point">#</a> <i>curve</i>.<b>point</b>(<i>x</i>, <i>y</i>) · [Source](https://github.com/d3/d3-shape/blob/master/src/curve/step.js)
+<a name="curve_point" href="#curve_point">#</a> <i>curve</i>.<b>point</b>(<i>x</i>, <i>y</i>) · [Source](https://github.com/d3/d3-shape/blob/main/src/curve/step.js)
 
 Indicates a new point in the current line segment with the given *x*- and *y*-values.
 
@@ -826,7 +826,7 @@ Indicates a new point in the current line segment with the given *x*- and *y*-va
 
 The **link** shape generates a smooth cubic Bézier curve from a source point to a target point. The tangents of the curve at the start and end are either [vertical](#linkVertical), [horizontal](#linkHorizontal) or [radial](#linkRadial).
 
-<a name="link" href="#link">#</a> d3.<b>link</b>(<i>curve<i>) · [Source](https://github.com/d3/d3-shape/blob/master/src/link/index.js)
+<a name="link" href="#link">#</a> d3.<b>link</b>(<i>curve<i>) · [Source](https://github.com/d3/d3-shape/blob/main/src/link.js)
 
 Returns a new [link generator](#_link) using the specified <i>curve</i>. For example, to visualize [links](https://github.com/d3/d3-hierarchy/blob/master/README.md#node_links) in a [tree diagram](https://github.com/d3/d3-hierarchy/blob/master/README.md#tree) rooted on the top edge of the display, you might say:
 
@@ -836,7 +836,7 @@ const link = d3.link(d3.curveBumpY)
     .y(d => d.y);
 ```
 
-<a name="linkVertical" href="#linkVertical">#</a> d3.<b>linkVertical</b>() · [Source](https://github.com/d3/d3-shape/blob/master/src/link/index.js)
+<a name="linkVertical" href="#linkVertical">#</a> d3.<b>linkVertical</b>() · [Source](https://github.com/d3/d3-shape/blob/main/src/link.js)
 
 Shorthand for [d3.link](#link) with [d3.curveBumpY](#curveBumpY); suitable for visualizing [links](https://github.com/d3/d3-hierarchy/blob/master/README.md#node_links) in a [tree diagram](https://github.com/d3/d3-hierarchy/blob/master/README.md#tree) rooted on the top edge of the display. Equivalent to:
 
@@ -844,7 +844,7 @@ Shorthand for [d3.link](#link) with [d3.curveBumpY](#curveBumpY); suitable for v
 const link = d3.link(d3.curveBumpY);
 ```
 
-<a name="linkHorizontal" href="#linkHorizontal">#</a> d3.<b>linkHorizontal</b>() · [Source](https://github.com/d3/d3-shape/blob/master/src/link/index.js)
+<a name="linkHorizontal" href="#linkHorizontal">#</a> d3.<b>linkHorizontal</b>() · [Source](https://github.com/d3/d3-shape/blob/main/src/link.js)
 
 Shorthand for [d3.link](#link) with [d3.curveBumpX](#curveBumpX); suitable for visualizing [links](https://github.com/d3/d3-hierarchy/blob/master/README.md#node_links) in a [tree diagram](https://github.com/d3/d3-hierarchy/blob/master/README.md#tree) rooted on the left edge of the display. Equivalent to:
 
@@ -852,7 +852,7 @@ Shorthand for [d3.link](#link) with [d3.curveBumpX](#curveBumpX); suitable for v
 const link = d3.link(d3.curveBumpX);
 ```
 
-<a href="#_link" name="_link">#</a> <i>link</i>(<i>arguments…</i>) · [Source](https://github.com/d3/d3-shape/blob/master/src/link/index.js)
+<a href="#_link" name="_link">#</a> <i>link</i>(<i>arguments…</i>) · [Source](https://github.com/d3/d3-shape/blob/main/src/link.js)
 
 Generates a link for the given *arguments*. The *arguments* are arbitrary; they are simply propagated to the link generator’s accessor functions along with the `this` object. For example, with the default settings, an object expected:
 
@@ -863,7 +863,7 @@ link({
 });
 ```
 
-<a name="link_source" href="#link_source">#</a> <i>link</i>.<b>source</b>([<i>source</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/link/index.js)
+<a name="link_source" href="#link_source">#</a> <i>link</i>.<b>source</b>([<i>source</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/link.js)
 
 If *source* is specified, sets the source accessor to the specified function and returns this link generator. If *source* is not specified, returns the current source accessor, which defaults to:
 
@@ -873,7 +873,7 @@ function source(d) {
 }
 ```
 
-<a name="link_target" href="#link_target">#</a> <i>link</i>.<b>target</b>([<i>target</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/link/index.js)
+<a name="link_target" href="#link_target">#</a> <i>link</i>.<b>target</b>([<i>target</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/link.js)
 
 If *target* is specified, sets the target accessor to the specified function and returns this link generator. If *target* is not specified, returns the current target accessor, which defaults to:
 
@@ -883,7 +883,7 @@ function target(d) {
 }
 ```
 
-<a name="link_x" href="#link_x">#</a> <i>link</i>.<b>x</b>([<i>x</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/link/index.js)
+<a name="link_x" href="#link_x">#</a> <i>link</i>.<b>x</b>([<i>x</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/link.js)
 
 If *x* is specified, sets the *x*-accessor to the specified function or number and returns this link generator. If *x* is not specified, returns the current *x*-accessor, which defaults to:
 
@@ -893,7 +893,7 @@ function x(d) {
 }
 ```
 
-<a name="link_y" href="#link_y">#</a> <i>link</i>.<b>y</b>([<i>y</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/link/index.js)
+<a name="link_y" href="#link_y">#</a> <i>link</i>.<b>y</b>([<i>y</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/link.js)
 
 If *y* is specified, sets the *y*-accessor to the specified function or number and returns this link generator. If *y* is not specified, returns the current *y*-accessor, which defaults to:
 
@@ -903,11 +903,11 @@ function y(d) {
 }
 ```
 
-<a name="link_context" href="#link_context">#</a> <i>link</i>.<b>context</b>([<i>context</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/link/index.js)
+<a name="link_context" href="#link_context">#</a> <i>link</i>.<b>context</b>([<i>context</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/link.js)
 
 If *context* is specified, sets the context and returns this link generator. If *context* is not specified, returns the current context, which defaults to null. If the context is not null, then the [generated link](#_link) is rendered to this context as a sequence of [path method](http://www.w3.org/TR/2dcontext/#canvaspathmethods) calls. Otherwise, a [path data](http://www.w3.org/TR/SVG/paths.html#PathData) string representing the generated link is returned. See also [d3-path](https://github.com/d3/d3-path).
 
-<a name="linkRadial" href="#linkRadial">#</a> d3.<b>linkRadial</b>() · [Source](https://github.com/d3/d3-shape/blob/master/src/link/index.js)
+<a name="linkRadial" href="#linkRadial">#</a> d3.<b>linkRadial</b>() · [Source](https://github.com/d3/d3-shape/blob/main/src/link.js)
 
 Returns a new [link generator](#_link) with radial tangents. For example, to visualize [links](https://github.com/d3/d3-hierarchy/blob/master/README.md#node_links) in a [tree diagram](https://github.com/d3/d3-hierarchy/blob/master/README.md#tree) rooted in the center of the display, you might say:
 
@@ -917,11 +917,11 @@ const link = d3.linkRadial()
     .radius(d => d.y);
 ```
 
-<a name="linkRadial_angle" href="#linkRadial_angle">#</a> <i>linkRadial</i>.<b>angle</b>([<i>angle</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/link/index.js)
+<a name="linkRadial_angle" href="#linkRadial_angle">#</a> <i>linkRadial</i>.<b>angle</b>([<i>angle</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/link.js)
 
 Equivalent to [*link*.x](#link_x), except the accessor returns the angle in radians, with 0 at -*y* (12 o’clock).
 
-<a name="linkRadial_radius" href="#linkRadial_radius">#</a> <i>linkRadial</i>.<b>radius</b>([<i>radius</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/link/index.js)
+<a name="linkRadial_radius" href="#linkRadial_radius">#</a> <i>linkRadial</i>.<b>radius</b>([<i>radius</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/link.js)
 
 Equivalent to [*link*.y](#link_y), except the accessor returns the radius: the distance from the origin ⟨0,0⟩.
 
@@ -931,15 +931,15 @@ Equivalent to [*link*.y](#link_y), except the accessor returns the radius: the d
 
 Symbols provide a categorical shape encoding as is commonly used in scatterplots. Symbols are always centered at ⟨0,0⟩; use a transform (see: [SVG](http://www.w3.org/TR/SVG/coords.html#TransformAttribute), [Canvas](http://www.w3.org/TR/2dcontext/#transformations)) to move the symbol to a different position.
 
-<a name="symbol" href="#symbol">#</a> d3.<b>symbol</b>([<i>type</i>][, <i>size</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/symbol.js), [Examples](https://observablehq.com/@d3/fitted-symbols)
+<a name="symbol" href="#symbol">#</a> d3.<b>symbol</b>([<i>type</i>][, <i>size</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/symbol.js), [Examples](https://observablehq.com/@d3/fitted-symbols)
 
 Constructs a new symbol generator of the specified [type](#symbol_type) and [size](#symbol_size). If not specified, *type* defaults to a circle, and *size* defaults to 64.
 
-<a name="_symbol" href="#_symbol">#</a> <i>symbol</i>(<i>arguments</i>…) · [Source](https://github.com/d3/d3-shape/blob/master/src/symbol.js)
+<a name="_symbol" href="#_symbol">#</a> <i>symbol</i>(<i>arguments</i>…) · [Source](https://github.com/d3/d3-shape/blob/main/src/symbol.js)
 
 Generates a symbol for the given *arguments*. The *arguments* are arbitrary; they are simply propagated to the symbol generator’s accessor functions along with the `this` object. For example, with the default settings, no arguments are needed to produce a circle with area 64 square pixels. If the symbol generator has a [context](#symbol_context), then the symbol is rendered to this context as a sequence of [path method](http://www.w3.org/TR/2dcontext/#canvaspathmethods) calls and this function returns void. Otherwise, a [path data](http://www.w3.org/TR/SVG/paths.html#PathData) string is returned.
 
-<a name="symbol_type" href="#symbol_type">#</a> <i>symbol</i>.<b>type</b>([<i>type</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/symbol.js)
+<a name="symbol_type" href="#symbol_type">#</a> <i>symbol</i>.<b>type</b>([<i>type</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/symbol.js)
 
 If *type* is specified, sets the symbol type to the specified function or symbol type and returns this symbol generator. If *type* is a function, the symbol generator’s arguments and *this* are passed through. (See [*selection*.attr](https://github.com/d3/d3-selection/blob/master/README.md#selection_attr) if you are using d3-selection.) If *type* is not specified, returns the current symbol type accessor, which defaults to:
 
@@ -951,7 +951,7 @@ function type() {
 
 See [symbolsFill](#symbolsFill) and [symbolsStroke](#symbolsStroke) for built-in symbol types. To implement a custom symbol type, pass an object that implements [*symbolType*.draw](#symbolType_draw).
 
-<a name="symbol_size" href="#symbol_size">#</a> <i>symbol</i>.<b>size</b>([<i>size</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/symbol.js)
+<a name="symbol_size" href="#symbol_size">#</a> <i>symbol</i>.<b>size</b>([<i>size</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/symbol.js)
 
 If *size* is specified, sets the size to the specified function or number and returns this symbol generator. If *size* is a function, the symbol generator’s arguments and *this* are passed through. (See [*selection*.attr](https://github.com/d3/d3-selection/blob/master/README.md#selection_attr) if you are using d3-selection.) If *size* is not specified, returns the current size accessor, which defaults to:
 
@@ -963,71 +963,71 @@ function size() {
 
 Specifying the size as a function is useful for constructing a scatterplot with a size encoding. If you wish to scale the symbol to fit a given bounding box, rather than by area, try [SVG’s getBBox](https://observablehq.com/d/1fac2626b9e1b65f).
 
-<a name="symbol_context" href="#symbol_context">#</a> <i>symbol</i>.<b>context</b>([<i>context</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/symbol.js)
+<a name="symbol_context" href="#symbol_context">#</a> <i>symbol</i>.<b>context</b>([<i>context</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/symbol.js)
 
 If *context* is specified, sets the context and returns this symbol generator. If *context* is not specified, returns the current context, which defaults to null. If the context is not null, then the [generated symbol](#_symbol) is rendered to this context as a sequence of [path method](http://www.w3.org/TR/2dcontext/#canvaspathmethods) calls. Otherwise, a [path data](http://www.w3.org/TR/SVG/paths.html#PathData) string representing the generated symbol is returned.
 
-<a name="symbolsFill" href="#symbolsFill">#</a> d3.<b>symbolsFill</b> · [Source](https://github.com/d3/d3-shape/blob/master/src/symbol.js)
+<a name="symbolsFill" href="#symbolsFill">#</a> d3.<b>symbolsFill</b> · [Source](https://github.com/d3/d3-shape/blob/main/src/symbol.js)
 
 An array containing a set of symbol types designed for filling: [circle](#symbolCircle), [cross](#symbolCross), [diamond](#symbolDiamond), [square](#symbolSquare), [star](#symbolStar), [triangle](#symbolTriangle), and [wye](#symbolWye). Useful for constructing the range of an [ordinal scale](https://github.com/d3/d3-scale#ordinal-scales) should you wish to use a shape encoding for categorical data.
 
-<a name="symbolsStroke" href="#symbolsStroke">#</a> d3.<b>symbolsStroke</b> · [Source](https://github.com/d3/d3-shape/blob/master/src/symbol.js)
+<a name="symbolsStroke" href="#symbolsStroke">#</a> d3.<b>symbolsStroke</b> · [Source](https://github.com/d3/d3-shape/blob/main/src/symbol.js)
 
 An array containing a set of symbol types designed for stroking: [circle](#symbolCircle), [plus](#symbolPlus), [x](#symbolX), [triangle2](#symbolTriangle2), [asterisk](#symbolAsterisk), [square2](#symbolSquare2), and [diamond2](#symbolDiamond2). Useful for constructing the range of an [ordinal scale](https://github.com/d3/d3-scale#ordinal-scales) should you wish to use a shape encoding for categorical data.
 
-<a name="symbolAsterisk" href="#symbolAsterisk">#</a> d3.<b>symbolAsterisk</b> · [Source](https://github.com/d3/d3-shape/blob/master/src/symbol/asterisk.js)
+<a name="symbolAsterisk" href="#symbolAsterisk">#</a> d3.<b>symbolAsterisk</b> · [Source](https://github.com/d3/d3-shape/blob/main/src/symbol/asterisk.js)
 
 The asterisk symbol type; intended for stroking.
 
-<a name="symbolCircle" href="#symbolCircle">#</a> d3.<b>symbolCircle</b> · [Source](https://github.com/d3/d3-shape/blob/master/src/symbol/circle.js)
+<a name="symbolCircle" href="#symbolCircle">#</a> d3.<b>symbolCircle</b> · [Source](https://github.com/d3/d3-shape/blob/main/src/symbol/circle.js)
 
 The circle symbol type; intended for either filling or stroking.
 
-<a name="symbolCross" href="#symbolCross">#</a> d3.<b>symbolCross</b> · [Source](https://github.com/d3/d3-shape/blob/master/src/symbol/cross.js)
+<a name="symbolCross" href="#symbolCross">#</a> d3.<b>symbolCross</b> · [Source](https://github.com/d3/d3-shape/blob/main/src/symbol/cross.js)
 
 The Greek cross symbol type, with arms of equal length; intended for filling.
 
-<a name="symbolDiamond" href="#symbolDiamond">#</a> d3.<b>symbolDiamond</b> · [Source](https://github.com/d3/d3-shape/blob/master/src/symbol/diamond.js)
+<a name="symbolDiamond" href="#symbolDiamond">#</a> d3.<b>symbolDiamond</b> · [Source](https://github.com/d3/d3-shape/blob/main/src/symbol/diamond.js)
 
 The rhombus symbol type; intended for filling.
 
-<a name="symbolDiamond2" href="#symbolDiamond2">#</a> d3.<b>symbolDiamond2</b> · [Source](https://github.com/d3/d3-shape/blob/master/src/symbol/diamond.js)
+<a name="symbolDiamond2" href="#symbolDiamond2">#</a> d3.<b>symbolDiamond2</b> · [Source](https://github.com/d3/d3-shape/blob/main/src/symbol/diamond.js)
 
 The rotated square symbol type; intended for stroking.
 
-<a name="symbolPlus" href="#symbolPlus">#</a> d3.<b>symbolPlus</b> · [Source](https://github.com/d3/d3-shape/blob/master/src/symbol/plus.js)
+<a name="symbolPlus" href="#symbolPlus">#</a> d3.<b>symbolPlus</b> · [Source](https://github.com/d3/d3-shape/blob/main/src/symbol/plus.js)
 
 The plus symbol type; intended for stroking.
 
-<a name="symbolSquare" href="#symbolSquare">#</a> d3.<b>symbolSquare</b> · [Source](https://github.com/d3/d3-shape/blob/master/src/symbol/square.js)
+<a name="symbolSquare" href="#symbolSquare">#</a> d3.<b>symbolSquare</b> · [Source](https://github.com/d3/d3-shape/blob/main/src/symbol/square.js)
 
 The square symbol type; intended for filling.
 
-<a name="symbolSquare2" href="#symbolSquare2">#</a> d3.<b>symbolSquare2</b> · [Source](https://github.com/d3/d3-shape/blob/master/src/symbol/square2.js)
+<a name="symbolSquare2" href="#symbolSquare2">#</a> d3.<b>symbolSquare2</b> · [Source](https://github.com/d3/d3-shape/blob/main/src/symbol/square2.js)
 
 The square2 symbol type; intended for stroking.
 
-<a name="symbolStar" href="#symbolStar">#</a> d3.<b>symbolStar</b> · [Source](https://github.com/d3/d3-shape/blob/master/src/symbol/star.js)
+<a name="symbolStar" href="#symbolStar">#</a> d3.<b>symbolStar</b> · [Source](https://github.com/d3/d3-shape/blob/main/src/symbol/star.js)
 
 The pentagonal star (pentagram) symbol type; intended for filling.
 
-<a name="symbolTriangle" href="#symbolTriangle">#</a> d3.<b>symbolTriangle</b> · [Source](https://github.com/d3/d3-shape/blob/master/src/symbol/triangle.js)
+<a name="symbolTriangle" href="#symbolTriangle">#</a> d3.<b>symbolTriangle</b> · [Source](https://github.com/d3/d3-shape/blob/main/src/symbol/triangle.js)
 
 The up-pointing triangle symbol type; intended for filling.
 
-<a name="symbolTriangle2" href="#symbolTriangle2">#</a> d3.<b>symbolTriangle2</b> · [Source](https://github.com/d3/d3-shape/blob/master/src/symbol/triangle2.js)
+<a name="symbolTriangle2" href="#symbolTriangle2">#</a> d3.<b>symbolTriangle2</b> · [Source](https://github.com/d3/d3-shape/blob/main/src/symbol/triangle2.js)
 
 The up-pointing triangle symbol type; intended for stroking.
 
-<a name="symbolWye" href="#symbolWye">#</a> d3.<b>symbolWye</b> · [Source](https://github.com/d3/d3-shape/blob/master/src/symbol/wye.js)
+<a name="symbolWye" href="#symbolWye">#</a> d3.<b>symbolWye</b> · [Source](https://github.com/d3/d3-shape/blob/main/src/symbol/wye.js)
 
 The Y-shape symbol type; intended for filling.
 
-<a name="symbolX" href="#symbolX">#</a> d3.<b>symbolX</b> · [Source](https://github.com/d3/d3-shape/blob/master/src/symbol/x.js)
+<a name="symbolX" href="#symbolX">#</a> d3.<b>symbolX</b> · [Source](https://github.com/d3/d3-shape/blob/main/src/symbol/x.js)
 
 The X-shape symbol type; intended for stroking.
 
-<a name="pointRadial" href="#pointRadial">#</a> d3.<b>pointRadial</b>(<i>angle</i>, <i>radius</i>) · [Source](https://github.com/d3/d3-shape/blob/master/src/pointRadial.js), [Examples](https://observablehq.com/@d3/radial-area-chart)
+<a name="pointRadial" href="#pointRadial">#</a> d3.<b>pointRadial</b>(<i>angle</i>, <i>radius</i>) · [Source](https://github.com/d3/d3-shape/blob/main/src/pointRadial.js), [Examples](https://observablehq.com/@d3/radial-area-chart)
 
 Returns the point [<i>x</i>, <i>y</i>] for the given *angle* in radians, with 0 at -*y* (12 o’clock) and positive angles proceeding clockwise, and the given *radius*.
 
@@ -1049,11 +1049,11 @@ Stacked charts can show overall value and per-category value simultaneously; how
 
 Like the [pie generator](#pies), the stack generator does not produce a shape directly. Instead it computes positions which you can then pass to an [area generator](#areas) or use directly, say to position bars.
 
-<a name="stack" href="#stack">#</a> d3.<b>stack</b>() · [Source](https://github.com/d3/d3-shape/blob/master/src/stack.js)
+<a name="stack" href="#stack">#</a> d3.<b>stack</b>() · [Source](https://github.com/d3/d3-shape/blob/main/src/stack.js)
 
 Constructs a new stack generator with the default settings.
 
-<a name="_stack" href="#_stack">#</a> <i>stack</i>(<i>data</i>[, <i>arguments…</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/stack.js)
+<a name="_stack" href="#_stack">#</a> <i>stack</i>(<i>data</i>[, <i>arguments…</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/stack.js)
 
 Generates a stack for the given array of *data*, returning an array representing each series. Any additional *arguments* are arbitrary; they are simply propagated to accessors along with the `this` object.
 
@@ -1103,11 +1103,11 @@ The resulting array has one element per *series*. Each series has one point per 
 
 Each series in then typically passed to an [area generator](#areas) to render an area chart, or used to construct rectangles for a bar chart.
 
-<a name="stack_keys" href="#stack_keys">#</a> <i>stack</i>.<b>keys</b>([<i>keys</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/stack.js)
+<a name="stack_keys" href="#stack_keys">#</a> <i>stack</i>.<b>keys</b>([<i>keys</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/stack.js)
 
 If *keys* is specified, sets the keys accessor to the specified function or array and returns this stack generator. If *keys* is not specified, returns the current keys accessor, which defaults to the empty array. A series (layer) is [generated](#_stack) for each key. Keys are typically strings, but they may be arbitrary values. The series’ key is passed to the [value accessor](#stack_value), along with each data point, to compute the point’s value.
 
-<a name="stack_value" href="#stack_value">#</a> <i>stack</i>.<b>value</b>([<i>value</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/stack.js)
+<a name="stack_value" href="#stack_value">#</a> <i>stack</i>.<b>value</b>([<i>value</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/stack.js)
 
 If *value* is specified, sets the value accessor to the specified function or number and returns this stack generator. If *value* is not specified, returns the current value accessor, which defaults to:
 
@@ -1119,7 +1119,7 @@ function value(d, key) {
 
 Thus, by default the stack generator assumes that the input data is an array of objects, with each object exposing named properties with numeric values; see [*stack*](#_stack) for an example.
 
-<a name="stack_order" href="#stack_order">#</a> <i>stack</i>.<b>order</b>([<i>order</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/stack.js)
+<a name="stack_order" href="#stack_order">#</a> <i>stack</i>.<b>order</b>([<i>order</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/stack.js)
 
 If *order* is specified, sets the order accessor to the specified function or array and returns this stack generator. If *order* is not specified, returns the current order accessor, which defaults to [stackOrderNone](#stackOrderNone); this uses the order given by the [key accessor](#stack_key). See [stack orders](#stack-orders) for the built-in orders.
 
@@ -1136,7 +1136,7 @@ function orderNone(series) {
 
 The stack order is computed prior to the [offset](#stack_offset); thus, the lower value for all points is zero at the time the order is computed. The index attribute for each series is also not set until after the order is computed.
 
-<a name="stack_offset" href="#stack_offset">#</a> <i>stack</i>.<b>offset</b>([<i>offset</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/stack.js)
+<a name="stack_offset" href="#stack_offset">#</a> <i>stack</i>.<b>offset</b>([<i>offset</i>]) · [Source](https://github.com/d3/d3-shape/blob/main/src/stack.js)
 
 If *offset* is specified, sets the offset accessor to the specified function and returns this stack generator. If *offset* is not specified, returns the current offset acccesor, which defaults to [stackOffsetNone](#stackOffsetNone); this uses a zero baseline. See [stack offsets](#stack-offsets) for the built-in offsets.
 
@@ -1158,27 +1158,27 @@ function offsetNone(series, order) {
 
 Stack orders are typically not used directly, but are instead passed to [*stack*.order](#stack_order).
 
-<a name="stackOrderAppearance" href="#stackOrderAppearance">#</a> d3.<b>stackOrderAppearance</b>(<i>series</i>) · [Source](https://github.com/d3/d3-shape/blob/master/src/order/appearance.js)
+<a name="stackOrderAppearance" href="#stackOrderAppearance">#</a> d3.<b>stackOrderAppearance</b>(<i>series</i>) · [Source](https://github.com/d3/d3-shape/blob/main/src/order/appearance.js)
 
 Returns a series order such that the earliest series (according to the maximum value) is at the bottom.
 
-<a name="stackOrderAscending" href="#stackOrderAscending">#</a> d3.<b>stackOrderAscending</b>(<i>series</i>) · [Source](https://github.com/d3/d3-shape/blob/master/src/order/ascending.js)
+<a name="stackOrderAscending" href="#stackOrderAscending">#</a> d3.<b>stackOrderAscending</b>(<i>series</i>) · [Source](https://github.com/d3/d3-shape/blob/main/src/order/ascending.js)
 
 Returns a series order such that the smallest series (according to the sum of values) is at the bottom.
 
-<a name="stackOrderDescending" href="#stackOrderDescending">#</a> d3.<b>stackOrderDescending</b>(<i>series</i>) · [Source](https://github.com/d3/d3-shape/blob/master/src/order/descending.js)
+<a name="stackOrderDescending" href="#stackOrderDescending">#</a> d3.<b>stackOrderDescending</b>(<i>series</i>) · [Source](https://github.com/d3/d3-shape/blob/main/src/order/descending.js)
 
 Returns a series order such that the largest series (according to the sum of values) is at the bottom.
 
-<a name="stackOrderInsideOut" href="#stackOrderInsideOut">#</a> d3.<b>stackOrderInsideOut</b>(<i>series</i>) · [Source](https://github.com/d3/d3-shape/blob/master/src/order/insideOut.js)
+<a name="stackOrderInsideOut" href="#stackOrderInsideOut">#</a> d3.<b>stackOrderInsideOut</b>(<i>series</i>) · [Source](https://github.com/d3/d3-shape/blob/main/src/order/insideOut.js)
 
 Returns a series order such that the earliest series (according to the maximum value) are on the inside and the later series are on the outside. This order is recommended for streamgraphs in conjunction with the [wiggle offset](#stackOffsetWiggle). See [Stacked Graphs—Geometry & Aesthetics](http://leebyron.com/streamgraph/) by Byron & Wattenberg for more information.
 
-<a name="stackOrderNone" href="#stackOrderNone">#</a> d3.<b>stackOrderNone</b>(<i>series</i>) · [Source](https://github.com/d3/d3-shape/blob/master/src/order/none.js)
+<a name="stackOrderNone" href="#stackOrderNone">#</a> d3.<b>stackOrderNone</b>(<i>series</i>) · [Source](https://github.com/d3/d3-shape/blob/main/src/order/none.js)
 
 Returns the given series order [0, 1, … *n* - 1] where *n* is the number of elements in *series*. Thus, the stack order is given by the [key accessor](#stack_keys).
 
-<a name="stackOrderReverse" href="#stackOrderReverse">#</a> d3.<b>stackOrderReverse</b>(<i>series</i>) · [Source](https://github.com/d3/d3-shape/blob/master/src/order/reverse.js)
+<a name="stackOrderReverse" href="#stackOrderReverse">#</a> d3.<b>stackOrderReverse</b>(<i>series</i>) · [Source](https://github.com/d3/d3-shape/blob/main/src/order/reverse.js)
 
 Returns the reverse of the given series order [*n* - 1, *n* - 2, … 0] where *n* is the number of elements in *series*. Thus, the stack order is given by the reverse of the [key accessor](#stack_keys).
 
@@ -1186,22 +1186,22 @@ Returns the reverse of the given series order [*n* - 1, *n* - 2, … 0] where *n
 
 Stack offsets are typically not used directly, but are instead passed to [*stack*.offset](#stack_offset).
 
-<a name="stackOffsetExpand" href="#stackOffsetExpand">#</a> d3.<b>stackOffsetExpand</b>(<i>series</i>, <i>order</i>) · [Source](https://github.com/d3/d3-shape/blob/master/src/offset/expand.js)
+<a name="stackOffsetExpand" href="#stackOffsetExpand">#</a> d3.<b>stackOffsetExpand</b>(<i>series</i>, <i>order</i>) · [Source](https://github.com/d3/d3-shape/blob/main/src/offset/expand.js)
 
 Applies a zero baseline and normalizes the values for each point such that the topline is always one.
 
-<a name="stackOffsetDiverging" href="#stackOffsetDiverging">#</a> d3.<b>stackOffsetDiverging</b>(<i>series</i>, <i>order</i>) · [Source](https://github.com/d3/d3-shape/blob/master/src/offset/diverging.js)
+<a name="stackOffsetDiverging" href="#stackOffsetDiverging">#</a> d3.<b>stackOffsetDiverging</b>(<i>series</i>, <i>order</i>) · [Source](https://github.com/d3/d3-shape/blob/main/src/offset/diverging.js)
 
 Positive values are stacked above zero, negative values are [stacked below zero](https://bl.ocks.org/mbostock/b5935342c6d21928111928401e2c8608), and zero values are stacked at zero.
 
-<a name="stackOffsetNone" href="#stackOffsetNone">#</a> d3.<b>stackOffsetNone</b>(<i>series</i>, <i>order</i>) · [Source](https://github.com/d3/d3-shape/blob/master/src/offset/none.js)
+<a name="stackOffsetNone" href="#stackOffsetNone">#</a> d3.<b>stackOffsetNone</b>(<i>series</i>, <i>order</i>) · [Source](https://github.com/d3/d3-shape/blob/main/src/offset/none.js)
 
 Applies a zero baseline.
 
-<a name="stackOffsetSilhouette" href="#stackOffsetSilhouette">#</a> d3.<b>stackOffsetSilhouette</b>(<i>series</i>, <i>order</i>) · [Source](https://github.com/d3/d3-shape/blob/master/src/offset/silhouette.js)
+<a name="stackOffsetSilhouette" href="#stackOffsetSilhouette">#</a> d3.<b>stackOffsetSilhouette</b>(<i>series</i>, <i>order</i>) · [Source](https://github.com/d3/d3-shape/blob/main/src/offset/silhouette.js)
 
 Shifts the baseline down such that the center of the streamgraph is always at zero.
 
-<a name="stackOffsetWiggle" href="#stackOffsetWiggle">#</a> d3.<b>stackOffsetWiggle</b>(<i>series</i>, <i>order</i>) · [Source](https://github.com/d3/d3-shape/blob/master/src/offset/wiggle.js)
+<a name="stackOffsetWiggle" href="#stackOffsetWiggle">#</a> d3.<b>stackOffsetWiggle</b>(<i>series</i>, <i>order</i>) · [Source](https://github.com/d3/d3-shape/blob/main/src/offset/wiggle.js)
 
 Shifts the baseline so as to minimize the weighted wiggle of layers. This offset is recommended for streamgraphs in conjunction with the [inside-out order](#stackOrderInsideOut). See [Stacked Graphs—Geometry & Aesthetics](http://leebyron.com/streamgraph/) by Bryon & Wattenberg for more information.

--- a/README.md
+++ b/README.md
@@ -826,24 +826,30 @@ Indicates a new point in the current line segment with the given *x*- and *y*-va
 
 The **link** shape generates a smooth cubic Bézier curve from a source point to a target point. The tangents of the curve at the start and end are either [vertical](#linkVertical), [horizontal](#linkHorizontal) or [radial](#linkRadial).
 
-<a name="linkVertical" href="#linkVertical">#</a> d3.<b>linkVertical</b>() · [Source](https://github.com/d3/d3-shape/blob/master/src/link/index.js)
+<a name="link" href="#link">#</a> d3.<b>link</b>(<i>curve<i>) · [Source](https://github.com/d3/d3-shape/blob/master/src/link/index.js)
 
-Returns a new [link generator](#_link) with vertical tangents. For example, to visualize [links](https://github.com/d3/d3-hierarchy/blob/master/README.md#node_links) in a [tree diagram](https://github.com/d3/d3-hierarchy/blob/master/README.md#tree) rooted on the top edge of the display, you might say:
+Returns a new [link generator](#_link) using the specified <i>curve</i>. For example, to visualize [links](https://github.com/d3/d3-hierarchy/blob/master/README.md#node_links) in a [tree diagram](https://github.com/d3/d3-hierarchy/blob/master/README.md#tree) rooted on the top edge of the display, you might say:
 
 ```js
-const link = d3.linkVertical()
+const link = d3.link(d3.curveBumpY)
     .x(d => d.x)
     .y(d => d.y);
 ```
 
-<a name="linkHorizontal" href="#linkHorizontal">#</a> d3.<b>linkHorizontal</b>() · [Source](https://github.com/d3/d3-shape/blob/master/src/link/index.js)
+<a name="linkVertical" href="#linkVertical">#</a> d3.<b>linkVertical</b>() · [Source](https://github.com/d3/d3-shape/blob/master/src/link/index.js)
 
-Returns a new [link generator](#_link) with horizontal tangents. For example, to visualize [links](https://github.com/d3/d3-hierarchy/blob/master/README.md#node_links) in a [tree diagram](https://github.com/d3/d3-hierarchy/blob/master/README.md#tree) rooted on the left edge of the display, you might say:
+Shorthand for [d3.link](#link) with [d3.curveBumpY](#curveBumpY); suitable for visualizing [links](https://github.com/d3/d3-hierarchy/blob/master/README.md#node_links) in a [tree diagram](https://github.com/d3/d3-hierarchy/blob/master/README.md#tree) rooted on the top edge of the display. Equivalent to:
 
 ```js
-const link = d3.linkHorizontal()
-    .x(d => d.y)
-    .y(d => d.x);
+const link = d3.link(d3.curveBumpY);
+```
+
+<a name="linkHorizontal" href="#linkHorizontal">#</a> d3.<b>linkHorizontal</b>() · [Source](https://github.com/d3/d3-shape/blob/master/src/link/index.js)
+
+Shorthand for [d3.link](#link) with [d3.curveBumpX](#curveBumpX); suitable for visualizing [links](https://github.com/d3/d3-hierarchy/blob/master/README.md#node_links) in a [tree diagram](https://github.com/d3/d3-hierarchy/blob/master/README.md#tree) rooted on the left edge of the display. Equivalent to:
+
+```js
+const link = d3.link(d3.curveBumpX);
 ```
 
 <a href="#_link" name="_link">#</a> <i>link</i>(<i>arguments…</i>) · [Source](https://github.com/d3/d3-shape/blob/master/src/link/index.js)
@@ -900,10 +906,6 @@ function y(d) {
 <a name="link_context" href="#link_context">#</a> <i>link</i>.<b>context</b>([<i>context</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/link/index.js)
 
 If *context* is specified, sets the context and returns this link generator. If *context* is not specified, returns the current context, which defaults to null. If the context is not null, then the [generated link](#_link) is rendered to this context as a sequence of [path method](http://www.w3.org/TR/2dcontext/#canvaspathmethods) calls. Otherwise, a [path data](http://www.w3.org/TR/SVG/paths.html#PathData) string representing the generated link is returned. See also [d3-path](https://github.com/d3/d3-path).
-
-<a name="link_curve" href="#link_curve">#</a> <i>link</i>.<b>curve</b>([<i>curve</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/link/index.js)
-
-If *curve* is specified, sets the curve and returns this link generator. If *curve* is not specified, returns the current curve, which defaults to [curveBumpX](#curveBumpX) for horizontal links, [curveBumpY](#curveBumpY) for vertical links.
 
 <a name="linkRadial" href="#linkRadial">#</a> d3.<b>linkRadial</b>() · [Source](https://github.com/d3/d3-shape/blob/master/src/link/index.js)
 

--- a/README.md
+++ b/README.md
@@ -901,6 +901,10 @@ function y(d) {
 
 If *context* is specified, sets the context and returns this link generator. If *context* is not specified, returns the current context, which defaults to null. If the context is not null, then the [generated link](#_link) is rendered to this context as a sequence of [path method](http://www.w3.org/TR/2dcontext/#canvaspathmethods) calls. Otherwise, a [path data](http://www.w3.org/TR/SVG/paths.html#PathData) string representing the generated link is returned. See also [d3-path](https://github.com/d3/d3-path).
 
+<a name="link_curve" href="#link_curve">#</a> <i>link</i>.<b>curve</b>([<i>curve</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/link/index.js)
+
+If *curve* is specified, sets the curve and returns this link generator. If *curve* is not specified, returns the current curve, which defaults to [curveBumpX](#curveBumpX) for horizontal links, [curveBumpY](#curveBumpY) for vertical links.
+
 <a name="linkRadial" href="#linkRadial">#</a> d3.<b>linkRadial</b>() · [Source](https://github.com/d3/d3-shape/blob/master/src/link/index.js)
 
 Returns a new [link generator](#_link) with radial tangents. For example, to visualize [links](https://github.com/d3/d3-hierarchy/blob/master/README.md#node_links) in a [tree diagram](https://github.com/d3/d3-hierarchy/blob/master/README.md#tree) rooted in the center of the display, you might say:

--- a/src/curve/bump.js
+++ b/src/curve/bump.js
@@ -1,3 +1,5 @@
+import pointRadial from "../pointRadial.js";
+
 class Bump {
   constructor(context, x) {
     this._context = context;
@@ -36,10 +38,37 @@ class Bump {
   }
 }
 
+class BumpRadial {
+  constructor(context) {
+    this._context = context;
+  }
+  lineStart() {
+    this._point = 0;
+  }
+  lineEnd() {}
+  point(x, y) {
+    x = +x, y = +y;
+    if (this._point++ === 0) {
+      this._x0 = x, this._y0 = y;
+    } else {
+      const p0 = pointRadial(this._x0, this._y0);
+      const p1 = pointRadial(this._x0, this._y0 = (this._y0 + y) / 2);
+      const p2 = pointRadial(x, this._y0);
+      const p3 = pointRadial(x, y);
+      this._context.moveTo(...p0);
+      this._context.bezierCurveTo(...p1, ...p2, ...p3);
+    }
+  }
+}
+
 export function bumpX(context) {
   return new Bump(context, true);
 }
 
 export function bumpY(context) {
   return new Bump(context, false);
+}
+
+export function bumpRadial(context) {
+  return new BumpRadial(context);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ export {default as pie} from "./pie.js";
 export {default as areaRadial, default as radialArea} from "./areaRadial.js"; // Note: radialArea is deprecated!
 export {default as lineRadial, default as radialLine} from "./lineRadial.js"; // Note: radialLine is deprecated!
 export {default as pointRadial} from "./pointRadial.js";
-export {linkHorizontal, linkVertical, linkRadial} from "./link.js";
+export {link, linkHorizontal, linkVertical, linkRadial} from "./link.js";
 
 export {default as symbol, symbolsStroke, symbolsFill, symbolsFill as symbols} from "./symbol.js";
 export {default as symbolAsterisk} from "./symbol/asterisk.js";

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ export {default as pie} from "./pie.js";
 export {default as areaRadial, default as radialArea} from "./areaRadial.js"; // Note: radialArea is deprecated!
 export {default as lineRadial, default as radialLine} from "./lineRadial.js"; // Note: radialLine is deprecated!
 export {default as pointRadial} from "./pointRadial.js";
-export {linkHorizontal, linkVertical, linkRadial} from "./link/index.js";
+export {linkHorizontal, linkVertical, linkRadial} from "./link.js";
 
 export {default as symbol, symbolsStroke, symbolsFill, symbolsFill as symbols} from "./symbol.js";
 export {default as symbolAsterisk} from "./symbol/asterisk.js";

--- a/src/link.js
+++ b/src/link.js
@@ -1,8 +1,8 @@
 import {path} from "d3-path";
-import {slice} from "../array.js";
-import constant from "../constant.js";
-import {x as pointX, y as pointY} from "../point.js";
-import {bumpX, bumpY, bumpRadial} from "../curve/bump.js";
+import {slice} from "./array.js";
+import constant from "./constant.js";
+import {x as pointX, y as pointY} from "./point.js";
+import {bumpX, bumpY, bumpRadial} from "./curve/bump.js";
 
 function linkSource(d) {
   return d.source;

--- a/src/link.js
+++ b/src/link.js
@@ -1,8 +1,8 @@
 import {path} from "d3-path";
 import {slice} from "./array.js";
 import constant from "./constant.js";
-import {x as pointX, y as pointY} from "./point.js";
 import {bumpX, bumpY, bumpRadial} from "./curve/bump.js";
+import {x as pointX, y as pointY} from "./point.js";
 
 function linkSource(d) {
   return d.source;

--- a/src/link/index.js
+++ b/src/link/index.js
@@ -1,6 +1,6 @@
-import {path} from "d3-path";
 import {slice} from "../array.js";
 import constant from "../constant.js";
+import line from "../line.js";
 import {x as pointX, y as pointY} from "../point.js";
 import pointRadial from "../pointRadial.js";
 import {bumpX as curveBumpX, bumpY as curveBumpY} from "../curve/bump.js";
@@ -17,17 +17,19 @@ function link(curve) {
   var source = linkSource,
       target = linkTarget,
       x = pointX,
-      y = pointY,
-      context = null;
-
+      y = pointY;
+  
+  const l = line().curve(curve);
+  
   function link() {
-    var buffer, argv = slice.call(arguments), s = source.apply(this, argv), t = target.apply(this, argv);
-    if (!context) context = curve(buffer = path());
-    context.lineStart();
-    context.point(+x.apply(this, (argv[0] = s, argv)), +y.apply(this, argv));
-    context.point(+x.apply(this, (argv[0] = t, argv)), +y.apply(this, argv));
-    context.lineEnd();
-    if (buffer) return context = null, buffer + "" || null;
+    const argv = slice.call(arguments);
+    const s = source.apply(this, argv);
+    const t = target.apply(this, argv);
+    const sx = +x.apply(this, (argv[0] = s, argv));
+    const sy = +y.apply(this, argv);
+    const tx = +x.apply(this, (argv[0] = t, argv));
+    const ty = +y.apply(this, argv);
+    return l([[sx, sy], [tx, ty]]);
   }
 
   link.source = function(_) {
@@ -47,11 +49,11 @@ function link(curve) {
   };
 
   link.context = function(_) {
-    return arguments.length ? ((context = _ == null ? null : _), link) : context;
+    return arguments.length ? (l.context(_ == null ? null : _), link) : l.context();
   };
   
   link.curve = function(_) {
-    return arguments.length ? (curve = _, link) : curve;
+    return arguments.length ? (l.curve(_), link) : l.curve();
   };
 
   return link;

--- a/test/link-test.js
+++ b/test/link-test.js
@@ -1,4 +1,5 @@
 import assert from "assert";
+import {path} from "d3-path";
 import {link, linkHorizontal, linkVertical} from "../src/index.js";
 import {curveLinear, curveBumpX, curveBumpY} from "../src/index.js";
 import {assertPathEqual} from "./asserts.js";
@@ -11,6 +12,42 @@ it("link(curve) returns a default link with the given curve", () => {
   assert.strictEqual(l.y()([42, 34]), 34);
   assert.strictEqual(l.context(), null);
   assertPathEqual(l({source: [0, 1], target: [2, 3]}), "M0,1L2,3");
+});
+
+it("link.source(source) sets source", () => {
+  const l = link(curveLinear);
+  const x = d => d.x;
+  assert.strictEqual(l.source(x), l);
+  assert.strictEqual(l.source(), x);
+  assertPathEqual(l({x: [0, 1], target: [2, 3]}), "M0,1L2,3");
+});
+
+it("link.target(target) sets target", () => {
+  const l = link(curveLinear);
+  const x = d => d.x;
+  assert.strictEqual(l.target(x), l);
+  assert.strictEqual(l.target(), x);
+  assertPathEqual(l({source: [0, 1], x: [2, 3]}), "M0,1L2,3");
+});
+
+it("link.source(f)(..args) passes arguments to the specified function f", () => {
+  const source = {name: "source"};
+  const target = {name: "target"};
+  const data = {source, target};
+  const extra = {name: "extra"};
+  const actual = [];
+  link(curveLinear).source(function(d) { actual.push([].slice.call(arguments)); return d; })(data, extra);
+  assert.deepStrictEqual(actual, [[data, extra]]);
+});
+
+it("link.target(f)(..args) passes source and arguments to the specified function f", () => {
+  const source = {name: "source"};
+  const target = {name: "target"};
+  const data = {source, target};
+  const extra = {name: "extra"};
+  const actual = [];
+  link(curveLinear).target(function(d) { actual.push([].slice.call(arguments)); return d; })(data, extra);
+  assert.deepStrictEqual(actual, [[data, extra]]);
 });
 
 it("link.x(x) sets x", () => {
@@ -67,4 +104,11 @@ it("linkVertical() is an alias for link(curveBumpY)", () => {
   assert.strictEqual(l.y(), l2.y());
   assert.strictEqual(l.context(), l2.context());
   assertPathEqual(l({source: [0, 1], target: [2, 3]}), l2({source: [0, 1], target: [2, 3]}));
+});
+
+it("link.context(context) sets the context", () => {
+  const p = path();
+  const l = link(curveLinear).context(p);
+  assert.strictEqual(l({source: [0, 1], target: [2, 3]}), undefined);
+  assertPathEqual(p, "M0,1L2,3");
 });

--- a/test/link-test.js
+++ b/test/link-test.js
@@ -1,0 +1,70 @@
+import assert from "assert";
+import {link, linkHorizontal, linkVertical} from "../src/index.js";
+import {curveLinear, curveBumpX, curveBumpY} from "../src/index.js";
+import {assertPathEqual} from "./asserts.js";
+
+it("link(curve) returns a default link with the given curve", () => {
+  const l = link(curveLinear);
+  assert.strictEqual(l.source()({source: 42}), 42);
+  assert.strictEqual(l.target()({target: 34}), 34);
+  assert.strictEqual(l.x()([42, 34]), 42);
+  assert.strictEqual(l.y()([42, 34]), 34);
+  assert.strictEqual(l.context(), null);
+  assertPathEqual(l({source: [0, 1], target: [2, 3]}), "M0,1L2,3");
+});
+
+it("link.x(x) sets x", () => {
+  const l = link(curveLinear);
+  const x = d => d.x;
+  assert.strictEqual(l.x(x), l);
+  assert.strictEqual(l.x(), x);
+  assertPathEqual(l({source: {x: 0, 1: 1}, target: {x: 2, 1: 3}}), "M0,1L2,3");
+});
+
+it("link.y(y) sets y", () => {
+  const l = link(curveLinear);
+  const y = d => d.y;
+  assert.strictEqual(l.y(y), l);
+  assert.strictEqual(l.y(), y);
+  assertPathEqual(l({source: {0: 0, y: 1}, target: {0: 2, y: 3}}), "M0,1L2,3");
+});
+
+it("link.x(f)(..args) passes source and arguments to the specified function f", () => {
+  const source = {name: "source"};
+  const target = {name: "target"};
+  const data = {source, target};
+  const extra = {name: "extra"};
+  const actual = [];
+  link(curveLinear).x(function() { actual.push([].slice.call(arguments)); })(data, extra);
+  assert.deepStrictEqual(actual, [[source, extra], [target, extra]]);
+});
+
+it("link.y(f)(..args) passes source and arguments to the specified function f", () => {
+  const source = {name: "source"};
+  const target = {name: "target"};
+  const data = {source, target};
+  const extra = {name: "extra"};
+  const actual = [];
+  link(curveLinear).y(function() { actual.push([].slice.call(arguments)); })(data, extra);
+  assert.deepStrictEqual(actual, [[source, extra], [target, extra]]);
+});
+
+it("linkHorizontal() is an alias for link(curveBumpX)", () => {
+  const l = linkHorizontal(), l2 = link(curveBumpX);
+  assert.strictEqual(l.source(), l2.source());
+  assert.strictEqual(l.target(), l2.target());
+  assert.strictEqual(l.x(), l2.x());
+  assert.strictEqual(l.y(), l2.y());
+  assert.strictEqual(l.context(), l2.context());
+  assertPathEqual(l({source: [0, 1], target: [2, 3]}), l2({source: [0, 1], target: [2, 3]}));
+});
+
+it("linkVertical() is an alias for link(curveBumpY)", () => {
+  const l = linkVertical(), l2 = link(curveBumpY);
+  assert.strictEqual(l.source(), l2.source());
+  assert.strictEqual(l.target(), l2.target());
+  assert.strictEqual(l.x(), l2.x());
+  assert.strictEqual(l.y(), l2.y());
+  assert.strictEqual(l.context(), l2.context());
+  assertPathEqual(l({source: [0, 1], target: [2, 3]}), l2({source: [0, 1], target: [2, 3]}));
+});


### PR DESCRIPTION
Test @ https://observablehq.com/d/504d8793ac6f9487


(We should also test the radial version, though it does not offer a curve option I had to rewrite it to match the internal API.)


### bumpX (default)
![bumpX](https://user-images.githubusercontent.com/7001/112769889-ebd82c00-9023-11eb-8ea6-e87eedc4ef73.png)

### others
![step](https://user-images.githubusercontent.com/7001/112769884-ea0e6880-9023-11eb-96ef-c568dfac209b.png)
![linear](https://user-images.githubusercontent.com/7001/112769887-eaa6ff00-9023-11eb-8fab-a844611b6769.png)
![bumpY](https://user-images.githubusercontent.com/7001/112769888-eb3f9580-9023-11eb-82aa-f682ef8991f4.png)
![stepBefore](https://user-images.githubusercontent.com/7001/112769890-ebd82c00-9023-11eb-8e51-dbb8af2afcbc.png)
![stepAfter](https://user-images.githubusercontent.com/7001/112769891-ec70c280-9023-11eb-99f3-b6ebf4934ec8.png)
