### PR TITLE
fix: remove build warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,6 @@
   "main": "src/index.js",
   "jsdelivr": "dist/d3-shape.min.js",
   "unpkg": "dist/d3-shape.min.js",
-  "exports": {
-    "umd": "./dist/d3-shape.min.js",
-    "default": "./src/index.js"
-  },
   "sideEffects": false,
   "dependencies": {
     "d3-path": "1 - 3"


### PR DESCRIPTION
### Package warning


warn Package d3-shape has been ignored because it contains invalid configuration. Reason: Package subpath './package.json' is not defined by "exports" in /node_modules/d3-shape/package.json