### PR TITLE
d3.link(curve) instead of link.curve(curve)

### DIFF
--- a/README.md
+++ b/README.md
@@ -815,24 +815,30 @@ Indicates a new point in the current line segment with the given *x*- and *y*-va
 
 The **link** shape generates a smooth cubic Bézier curve from a source point to a target point. The tangents of the curve at the start and end are either [vertical](#linkVertical), [horizontal](#linkHorizontal) or [radial](#linkRadial).
 
-<a name="linkVertical" href="#linkVertical">#</a> d3.<b>linkVertical</b>() · [Source](https://github.com/d3/d3-shape/blob/master/src/link/index.js)
+<a name="link" href="#link">#</a> d3.<b>link</b>(<i>curve<i>) · [Source](https://github.com/d3/d3-shape/blob/master/src/link/index.js)
 
-Returns a new [link generator](#_link) with vertical tangents. For example, to visualize [links](https://github.com/d3/d3-hierarchy/blob/master/README.md#node_links) in a [tree diagram](https://github.com/d3/d3-hierarchy/blob/master/README.md#tree) rooted on the top edge of the display, you might say:
+Returns a new [link generator](#_link) using the specified <i>curve</i>. For example, to visualize [links](https://github.com/d3/d3-hierarchy/blob/master/README.md#node_links) in a [tree diagram](https://github.com/d3/d3-hierarchy/blob/master/README.md#tree) rooted on the top edge of the display, you might say:
 
 ```js
-const link = d3.linkVertical()
+const link = d3.link(d3.curveBumpY)
     .x(d => d.x)
     .y(d => d.y);
 ```
 
-<a name="linkHorizontal" href="#linkHorizontal">#</a> d3.<b>linkHorizontal</b>() · [Source](https://github.com/d3/d3-shape/blob/master/src/link/index.js)
+<a name="linkVertical" href="#linkVertical">#</a> d3.<b>linkVertical</b>() · [Source](https://github.com/d3/d3-shape/blob/master/src/link/index.js)
 
-Returns a new [link generator](#_link) with horizontal tangents. For example, to visualize [links](https://github.com/d3/d3-hierarchy/blob/master/README.md#node_links) in a [tree diagram](https://github.com/d3/d3-hierarchy/blob/master/README.md#tree) rooted on the left edge of the display, you might say:
+Shorthand for [d3.link](#link) with [d3.curveBumpY](#curveBumpY); suitable for visualizing [links](https://github.com/d3/d3-hierarchy/blob/master/README.md#node_links) in a [tree diagram](https://github.com/d3/d3-hierarchy/blob/master/README.md#tree) rooted on the top edge of the display. Equivalent to:
 
 ```js
-const link = d3.linkHorizontal()
-    .x(d => d.y)
-    .y(d => d.x);
+const link = d3.link(d3.curveBumpY);
+```
+
+<a name="linkHorizontal" href="#linkHorizontal">#</a> d3.<b>linkHorizontal</b>() · [Source](https://github.com/d3/d3-shape/blob/master/src/link/index.js)
+
+Shorthand for [d3.link](#link) with [d3.curveBumpX](#curveBumpX); suitable for visualizing [links](https://github.com/d3/d3-hierarchy/blob/master/README.md#node_links) in a [tree diagram](https://github.com/d3/d3-hierarchy/blob/master/README.md#tree) rooted on the left edge of the display. Equivalent to:
+
+```js
+const link = d3.link(d3.curveBumpX);
 ```
 
 <a href="#_link" name="_link">#</a> <i>link</i>(<i>arguments…</i>) · [Source](https://github.com/d3/d3-shape/blob/master/src/link/index.js)
@@ -889,10 +895,6 @@ function y(d) {
 <a name="link_context" href="#link_context">#</a> <i>link</i>.<b>context</b>([<i>context</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/link/index.js)
 
 If *context* is specified, sets the context and returns this link generator. If *context* is not specified, returns the current context, which defaults to null. If the context is not null, then the [generated link](#_link) is rendered to this context as a sequence of [path method](http://www.w3.org/TR/2dcontext/#canvaspathmethods) calls. Otherwise, a [path data](http://www.w3.org/TR/SVG/paths.html#PathData) string representing the generated link is returned. See also [d3-path](https://github.com/d3/d3-path).
-
-<a name="link_curve" href="#link_curve">#</a> <i>link</i>.<b>curve</b>([<i>curve</i>]) · [Source](https://github.com/d3/d3-shape/blob/master/src/link/index.js)
-
-If *curve* is specified, sets the curve and returns this link generator. If *curve* is not specified, returns the current curve, which defaults to [curveBumpX](#curveBumpX) for horizontal links, [curveBumpY](#curveBumpY) for vertical links.
 
 <a name="linkRadial" href="#linkRadial">#</a> d3.<b>linkRadial</b>() · [Source](https://github.com/d3/d3-shape/blob/master/src/link/index.js)
 

--- a/src/curve/bump.js
+++ b/src/curve/bump.js
@@ -1,3 +1,5 @@
+import pointRadial from "../pointRadial.js";
+
 class Bump {
   constructor(context, x) {
     this._context = context;
@@ -36,10 +38,37 @@ class Bump {
   }
 }
 
+class BumpRadial {
+  constructor(context) {
+    this._context = context;
+  }
+  lineStart() {
+    this._point = 0;
+  }
+  lineEnd() {}
+  point(x, y) {
+    x = +x, y = +y;
+    if (this._point++ === 0) {
+      this._x0 = x, this._y0 = y;
+    } else {
+      const p0 = pointRadial(this._x0, this._y0);
+      const p1 = pointRadial(this._x0, this._y0 = (this._y0 + y) / 2);
+      const p2 = pointRadial(x, this._y0);
+      const p3 = pointRadial(x, y);
+      this._context.moveTo(...p0);
+      this._context.bezierCurveTo(...p1, ...p2, ...p3);
+    }
+  }
+}
+
 export function bumpX(context) {
   return new Bump(context, true);
 }
 
 export function bumpY(context) {
   return new Bump(context, false);
+}
+
+export function bumpRadial(context) {
+  return new BumpRadial(context);
 }

--- a/src/link/index.js
+++ b/src/link/index.js
@@ -13,23 +13,21 @@ function linkTarget(d) {
   return d.target;
 }
 
-function link(curve) {
+export function link(curve) {
   var source = linkSource,
       target = linkTarget,
       x = pointX,
-      y = pointY;
-  
-  const l = line().curve(curve);
-  
+      y = pointY,
+      l = line().curve(curve);
+
   function link() {
     const argv = slice.call(arguments);
     const s = source.apply(this, argv);
     const t = target.apply(this, argv);
-    const sx = +x.apply(this, (argv[0] = s, argv));
-    const sy = +y.apply(this, argv);
-    const tx = +x.apply(this, (argv[0] = t, argv));
-    const ty = +y.apply(this, argv);
-    return l([[sx, sy], [tx, ty]]);
+    return l([
+      (argv[0] = s, [+x.apply(this, argv), +y.apply(this, argv)]),
+      (argv[0] = t, [+x.apply(this, argv), +y.apply(this, argv)])
+    ]);
   }
 
   link.source = function(_) {
@@ -49,14 +47,25 @@ function link(curve) {
   };
 
   link.context = function(_) {
-    return arguments.length ? (l.context(_ == null ? null : _), link) : l.context();
-  };
-  
-  link.curve = function(_) {
-    return arguments.length ? (l.curve(_), link) : l.curve();
+    return arguments.length ? (l.context(_), link) : l.context();
   };
 
   return link;
+}
+
+export function linkHorizontal() {
+  return link(curveBumpX);
+}
+
+export function linkVertical() {
+  return link(curveBumpY);
+}
+
+export function linkRadial() {
+  var l = link(curveRadial);
+  l.angle = l.x, delete l.x;
+  l.radius = l.y, delete l.y;
+  return l;
 }
 
 class CurveRadial {
@@ -84,20 +93,4 @@ class CurveRadial {
 
 function curveRadial(context) {
   return new CurveRadial(context);
-}
-
-export function linkHorizontal() {
-  return link(curveBumpX);
-}
-
-export function linkVertical() {
-  return link(curveBumpY);
-}
-
-export function linkRadial() {
-  var l = link(curveRadial);
-  l.angle = l.x, delete l.x;
-  l.radius = l.y, delete l.y;
-  delete l.curve;
-  return l;
 }


### PR DESCRIPTION
Feels weird to say d3.linkHorizontal().curve(whatever), so instead, d3.link(whatever).