### PR TITLE
`sampling()` accessor to allow data sampling for `d3.area` and `d3.line`

### DIFF
--- a/src/area.js
+++ b/src/area.js
@@ -8,6 +8,7 @@ import {x as pointX, y as pointY} from "./point.js";
 export default function(x0, y0, y1) {
   var x1 = null,
       defined = constant(true),
+      sampling = constant(true),
       context = null,
       curve = curveLinear,
       output = null;
@@ -39,13 +40,13 @@ export default function(x0, y0, y1) {
           output.lineEnd();
           output.lineStart();
           for (k = i - 1; k >= j; --k) {
-            output.point(x0z[k], y0z[k]);
+            if (!isNaN(x0z[k]) && !isNaN(y0z[k])) output.point(x0z[k], y0z[k]);
           }
           output.lineEnd();
           output.areaEnd();
         }
       }
-      if (defined0) {
+      if (defined0 && sampling(d = data[i], i, data)) {
         x0z[i] = +x0(d, i, data), y0z[i] = +y0(d, i, data);
         output.point(x1 ? +x1(d, i, data) : x0z[i], y1 ? +y1(d, i, data) : y0z[i]);
       }
@@ -97,6 +98,10 @@ export default function(x0, y0, y1) {
 
   area.defined = function(_) {
     return arguments.length ? (defined = typeof _ === "function" ? _ : constant(!!_), area) : defined;
+  };
+
+  area.sampling = function(_) {
+    return arguments.length ? (sampling = typeof _ === "function" ? _ : constant(!!_), area) : sampling;
   };
 
   area.curve = function(_) {

--- a/src/line.js
+++ b/src/line.js
@@ -6,6 +6,7 @@ import {x as pointX, y as pointY} from "./point.js";
 
 export default function(x, y) {
   var defined = constant(true),
+      sampling = constant(true),
       context = null,
       curve = curveLinear,
       output = null;
@@ -27,7 +28,7 @@ export default function(x, y) {
         if (defined0 = !defined0) output.lineStart();
         else output.lineEnd();
       }
-      if (defined0) output.point(+x(d, i, data), +y(d, i, data));
+      if (defined0 && sampling(d = data[i], i, data)) output.point(+x(d, i, data), +y(d, i, data));
     }
 
     if (buffer) return output = null, buffer + "" || null;
@@ -43,6 +44,10 @@ export default function(x, y) {
 
   line.defined = function(_) {
     return arguments.length ? (defined = typeof _ === "function" ? _ : constant(!!_), line) : defined;
+  };
+
+  line.sampling = function (_) {
+    return arguments.length ? (sampling = typeof _ === "function" ? _ : constant(!!_), line): sampling;
   };
 
   line.curve = function(_) {


### PR DESCRIPTION
Creation of an accessor `sampling` to allow d3.area and d3.line sampling (skip data point based on a function), based on the accessor `defined`.